### PR TITLE
Fix auditwheel args and build options on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/GR\", \"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       id: cache
       with:
         path: skia/out/Release
-        key: ${{ matrix.container }}-skia-${{ hashFiles('submodule.txt') }}
+        key: ${{ matrix.container }}-skia-out-${{ hashFiles('submodule.txt') }}
     - name: Set PATH
       run: echo "::add-path::$PWD/depot_tools"
       if: steps.cache.outputs.cache-hit != 'true'
@@ -51,7 +51,7 @@ jobs:
         cd skia
         python tools/git-sync-deps
         cp -f ../gn/out/gn bin/gn  # Replace gn.
-        bin/gn gen out/Release --args='is_official_build=false is_debug=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
+        bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
         ninja -C out/Release skia skia.h
         rm -rf out/Release/obj
         cd ..
@@ -82,7 +82,7 @@ jobs:
       id: cache
       with:
         path: skia/out/Release
-        key: ${{ runner.os }}-skia-${{ hashFiles('submodule.txt') }}
+        key: ${{ runner.os }}-skia-out-${{ hashFiles('submodule.txt') }}
     - name: Set up Python 2.7
       uses: actions/setup-python@v1
       with:
@@ -95,7 +95,7 @@ jobs:
       run: |
         cd skia
         python tools/git-sync-deps
-        bin/gn gen out/Release --args='is_official_build=false is_debug=false extra_cflags_cc=["-frtti"]'
+        bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
         ninja -C out/Release skia skia.h
         rm -rf out/Release/obj
         cd ..
@@ -142,7 +142,7 @@ jobs:
       id: cache
       with:
         path: skia\out\Release
-        key: ${{ runner.os }}-${{ matrix.arch }}-skia-${{ hashFiles('submodule.txt') }}
+        key: ${{ runner.os }}-${{ matrix.arch }}-skia-out-${{ hashFiles('submodule.txt') }}
     - name: Set up Python 2.7
       uses: actions/setup-python@v1
       with:
@@ -155,7 +155,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=false is_debug=false extra_cflags_cc=[\"/GR\", \"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Release wheels
 on:
   release:
     types: [created]
+  push:
+    branches: [improve-wheel-upload]
 
 jobs:
   build-linux:
@@ -55,13 +57,13 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip install --no-cache-dir pybind11 numpy wheel twine
-        python -m pip wheel . -w dist --no-deps
-        auditwheel repair dist/skia*.whl
+        python -m pip wheel . -w dist --no-deps --verbose
+        auditwheel repair dist/skia*.whl -w wheelhouse
     - name: Upload wheels
       uses: actions/upload-artifact@v1
       with:
-        name: dist
-        path: dist
+        name: ${{ matrix.container }}-${{ matrix.python-version }}
+        path: wheelhouse
   build-macos:
     runs-on: macos-latest
     strategy:
@@ -96,12 +98,12 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip install --no-cache-dir pybind11 numpy wheel twine
-        python -m pip wheel . -w dist --no-deps
+        python -m pip wheel . -w wheelhouse --no-deps
     - name: Upload wheels
       uses: actions/upload-artifact@v1
       with:
-        name: dist
-        path: dist
+        name: macos-${{ matrix.python-version }}
+        path: wheelhouse
   build-windows:
     runs-on: windows-latest
     strategy:
@@ -146,9 +148,9 @@ jobs:
         }
         python -m pip install -U pip
         python -m pip install --no-cache-dir pybind11 numpy wheel twine
-        python -m pip wheel . -w dist --no-deps
+        python -m pip wheel . -w wheelhouse --no-deps
     - name: Upload wheels
       uses: actions/upload-artifact@v1
       with:
-        name: dist
-        path: dist
+        name: windows-${{ matrix.arch }}-${{ matrix.python-version }}
+        path: wheelhouse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/GR\", \"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release wheels
 on:
   release:
     types: [created]
-  push:
-    branches: [improve-wheel-upload]
 
 jobs:
   build-linux:
@@ -47,7 +45,7 @@ jobs:
         cd skia
         python tools/git-sync-deps
         cp -f ../gn/out/gn bin/gn  # Replace gn.
-        bin/gn gen out/Release --args='is_official_build=false is_debug=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
+        bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
         ninja -C out/Release skia skia.h
         rm -rf out/Release/obj
         cd ..
@@ -83,7 +81,7 @@ jobs:
       run: |
         cd skia
         python tools/git-sync-deps
-        bin/gn gen out/Release --args='is_official_build=false is_debug=false extra_cflags_cc=["-frtti"]'
+        bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
         ninja -C out/Release skia skia.h
         rm -rf out/Release/obj
         cd ..
@@ -124,7 +122,7 @@ jobs:
       run: |
         cd skia
         python tools\git-sync-deps
-        bin\gn gen out\Release --args='is_official_build=false is_debug=false extra_cflags_cc=[\"/GR\", \"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
+        bin\gn gen out\Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=[\"/EHsc\"] target_cpu=\"${{ matrix.arch }}\"'
         ninja -C out\Release skia skia.h
         rm out\Release\obj -r -fo
         cd ..

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ if sys.platform == 'win32':
         '/std:c++latest',
         '/DVERSION_INFO=%s' % __version__,
         '/Zc:inline',
-        '/GR',
         # Disable a bunch of warnings.
         '/wd5030',  # Warnings about unknown attributes.
         '/wd4244',  # Conversion from 'float' to 'int', possible loss of data.
@@ -114,7 +113,7 @@ else:
     ]
     EXTRA_LINK_ARGS = [
         '-Wl,--gc-sections',
-        '-Os',
+        '-O3',
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ else:
     ]
     EXTRA_LINK_ARGS = [
         '-Wl,--gc-sections',
+        '-Os',
     ]
 
 


### PR DESCRIPTION
Linux binary tends to become large. Adds `-Os` flag to mitigate.