### PR TITLE
Add /MT linker flag on win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ if sys.platform == 'win32':
         '/wd4180',  # Qualifier applied to function type has no meaning.
     ]
     EXTRA_LINK_ARGS = [
+        '/MT',
         '/OPT:ICF',
         '/OPT:REF',
     ]


### PR DESCRIPTION
- Fix windows build error