### PR TITLE
Fix windows build /MD flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         arch: [ x64 ]
-        python-version: [3.7]
+        python-version: [3.5, 3.7]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if sys.platform == 'win32':
         '/wd4267',  # Conversion from 'size_t' to 'int', possible loss of data.
         '/wd4800',  # Forcing value to bool 'true' or 'false'.
         '/wd4180',  # Qualifier applied to function type has no meaning.
+        '/MD',      # Bugfix: https://bugs.python.org/issue38597
     ]
     EXTRA_LINK_ARGS = [
         '/OPT:ICF',


### PR DESCRIPTION
Windows release build fails on certain python versions, due to the `/MT` vs `/MD` problem. This fix explicitly add /MD compile flag.

Related: https://bugs.python.org/issue38597
