### PR TITLE
Fix gn build in linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         git clone https://gn.googlesource.com/gn
         cd gn
+        git checkout 981f46c64d1456d2083b1a2fa1367e753e0cdc1b
         python build/gen.py
         ninja -C out gn
         cd ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         CC: gcc
         CXX: g++
         AR: ar
+        CFLAGS: -Wno-deprecated-copy
         LDFLAGS: -lrt
       run: |
         git clone https://gn.googlesource.com/gn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,12 @@ jobs:
         CC: gcc
         CXX: g++
         AR: ar
+        CFLAGS: -Wno-deprecated-copy
         LDFLAGS: -lrt
       run: |
         git clone https://gn.googlesource.com/gn
         cd gn
+        git checkout 981f46c64d1456d2083b1a2fa1367e753e0cdc1b
         python build/gen.py
         ninja -C out gn
         cd ..


### PR DESCRIPTION
- Set gn to specific commit to avoid unstable gcc build