### PR TITLE
Improve Font APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ For unsupported environment, check the [build instruction](https://kyamagu.githu
 - [Path Overview](https://github.com/kyamagu/skia-python/blob/master/notebooks/Path-Overview.ipynb)
 - [Paint Overview](https://github.com/kyamagu/skia-python/blob/master/notebooks/Paint-Overview.ipynb)
 - [Python Image I/O](https://github.com/kyamagu/skia-python/blob/master/notebooks/Python-Image-IO.ipynb)
+- [Drawing Texts](https://github.com/kyamagu/skia-python/blob/master/notebooks/Drawing-Texts.ipynb)
 
 ## Documentation
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -17,4 +17,5 @@ Notebook examples
 - `Canvas Creation <https://github.com/kyamagu/skia-python/blob/master/notebooks/Canvas-Creation.ipynb>`_
 - `Path Overview <https://github.com/kyamagu/skia-python/blob/master/notebooks/Path-Overview.ipynb>`_
 - `Paint Overview <https://github.com/kyamagu/skia-python/blob/master/notebooks/Paint-Overview.ipynb>`_
+- `Drawing Texts <https://github.com/kyamagu/skia-python/blob/master/notebooks/Drawing-Texts.ipynb>`_
 - `Python Image I/O <https://github.com/kyamagu/skia-python/blob/master/notebooks/Python-Image-IO.ipynb>`_

--- a/notebooks/Drawing-Texts.ipynb
+++ b/notebooks/Drawing-Texts.ipynb
@@ -1,0 +1,586 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Drawing Texts\n",
+    "\n",
+    "This notebook demonstrates basic text rendering APIs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import skia\n",
+    "import contextlib\n",
+    "from IPython.display import display, Image\n",
+    "\n",
+    "@contextlib.contextmanager\n",
+    "def draw_target(width=256, height=128):\n",
+    "    surface = skia.Surface(width, height)\n",
+    "    canvas = surface.getCanvas()\n",
+    "    yield canvas\n",
+    "    image = surface.makeImageSnapshot()\n",
+    "    display(Image(data=image.encodeToData()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In Skia, texts can be drawn onto a canvas via `drawString()` or `drawTextBlob()`. `TextBlob` combines multiple text runs into an immutable container, and allows finer control of glyphs, paint, and positions for each run. The following example shows `drawString()` and `drawTextBlob()` with position specifications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAAD5hJREFUeJztnXe0FsUVwH+jgFhAsSAaQgyCWLFENBZK7MZuLIn9xGiixmhO1CRESVERPYlGTfAYNR4xtqixYcUeIooiSgBFBVHQCGIJL3bh5o/Zp7Ozs7uz+/Zrj/m9s+d9u3tndr797k65c+cuBAKBQCAQCASWOVQVmQhsBuwADIy2QcDHwCxgDjAbuEPBwiquV7KMmwIrR7vvKHilUWXpNAisLXC5gHhuFwt8vUFlnWeU455GlKFTIbBLgR/e3nbLyLePwBnGNqCi8gYFcNClTCKB3sB1jlMvoav9+cCawObABg65WwS2VfCC41x/4Hxjfw6huq4ZpRQAuBKtBO3MBE5R8KAtKNAdOAsYaRzuAYwX2FTBRyXLUJQHgX7R52fqdM3Oh8BXrOp8gcSVIS3dUEdTsI1DbntL5qDafJMAwHIl0mxm7Y/y6d0r+Ccwxjo8uMT1AxVSpgnY3Np/vkDaG4FfGPtbtn8QPXTsZR6L2ER0nwLgBQX/teQB3lAwLzq+LfAt9PlpCi6Kjq8LrBjJL1bwtnmRaJi4SrQ7V8Fb0fFVga2AIej+zEvoJmSqgvd8v7jA6sDW6AeoO7q8T7f3gwS6AitF4p/WsWkshsD5VhX9vQJpuwjcI/BAtI0yzk3yGD0cnCI/VqB79N+Uf8SQzxwFWOdHCfQSuCqnPD/3+M69BG7PyGO8wHoCv3aVu9aUqQGes/bPFHhYwYK8hAo+B75d4pp5dAOuBw6oKL9+6Ke8f47cGIHPFFzoOim6ibstJ5+90LXqJONY1wJlrS8CAx1aPE/glKiaLZvvH6JaYYaV9yyjxtjekPepMcrWAPY2WeAGgYkp5+1mC4HeGfk9IDA74/zEsvex5ggogYcyCj9D4EKB/QTWKZG/1yggQwEuEdhToL/AGoZ8GQVYILC3JdcvOm7KjXLkd7El87zAjmI83QKbRQreOgoAINBTYIrHEyiRpl8tcLho41Be3h1RgD0y8i2qALNNBbJkd7Jkb7fOD3CUbVBKXj0dtUFzKwCAwJrR0+ajBOZ2pyRHEma+ZRXg3JzyFlWA72Tk1dOSnWSdv8A6f0RO2Y5oOQVoJ1KEIwWuE1hcQBGOTMmvrAKsnlPOIgqwQHJmSq2ndpZ1brxVtm45eXWx7l3dFKCMISiGgkUKrlVwOHpcvhnwfeAqvhy/uxgnRqeug8xX8G5FeQFMVyA5MrONz/ZoaiPj8/0KPs3KKBodTStQvsrosAKYKFii9M27WsEPFHwV2BA4Fbcy3Jb3pHnyagV5mLSVTShaGcxhX9ZDYDKn7DU7QqUK4ELBLAUXo/0AzrJO9wbWr3UZSvBJB9Kube371kwNGfsXUgCBAwTuM7atfNMq+FzBOcAd1qnUDmGL8r61v4pTKolr2rzmFK0BBNjd2LYucc37rX3n8KhVUfAB8cmxfmmy7USdRO+HqUqKKsB0a394iWv2sPYb0vbVmJeNz5t79HMa9hAUVQC7s3WY5NvLbexh3ZSC6VsBUwH6kmGgiji+hmXJpJACKFgC3GUdniTwjby0AssJHIeeVm2njfhwykX3ImVsEu629n8rX3okx4juyY9rXyQ3ZUYBJxEfJvUGnhE4ThyTQQJdI8vfBOAv1ukbFCy1jr1jX0/qMFqpmFuBh439IcDjon0bVPQwDBY4jeQ9aX4EDsqw8C0WeETgH+Ke6DBNwgkLWXSD7MkWiSx1OxtypiXwcY8yF7EE3uSR3wOGfKIWi37stPuTZzFtbkuggluAE3EbTHoAI9Bz82lDmwnAoS4LWWSBs5sZ0G1pprm3mVAwA9iJpCGoB8mO8NnEv/NnNSxajNJVq4LL0MadPxZIdjP6Kd4jx+VpDPmmUfMmfexx7Q+Nz5/nnPcxBJnK68oPpf0RNkR/n5kOkZloi+ko4krxtkO2JlS1NGxdtP17/WgbhG7b56J9314HJil4s0Cey6Of+vWivBYCr0Qd0ZZEtM/fALTyvK2M/k40odReY45Vuq8VaEUEuon2BWzfMmtagdWtPoBtMg+0EgInWz9opq+i6JGOKb9DvcoaqAECQ6wfdHLUpLlk97FkF6TJBloEgeUdQ70poifTNolsAEcJ/NkxBKyrUah4J1AYAGxcIMXrwL9Rnp03YVu+nFJ9C8XkYgUsgNAd7bzSzt0oXqsma0ZQ3L//LmB/h3GsiRBuR0r9LUR4DMmZ9hQWGWly1xp08LtsYpXxtGqzZ68Uo5ZrGy0N8Akouzq4DGtF2wyEw1DcXMdrNwQFd4seyu4P7Iu2mwxEL1GbF20TgFuVHjK3AOVrAPvvpyn5d5oaoBWoogYYiV6WZbMC+onfFDiKpAPoGITLUF5WvEDTkKwBjvZMN9JRCyRdw0MNUFfqN82qGE20hNtgi7pdP+Cknp1AgCeAQ439wmsHE+hh43C09WwQWqmnAU8B96CYUSLP1dBePHug4w28B0xGB7m4FxWbOFrGKNsE6LQTrLSJRZXeTYCwOsJUj87m9cgXgSHsPJJNgPBdhCUZ+bUhDPP+zp2O8n2ArtHNM/+SvnI+CiDshPCBx4/f/rcYScYjcijAggJ5/q7YjesslFEAYUWE6Va6/6TIZiuAsI7jCV2CMBvhRnQts9jxgy1CrCYvqQCuPCcivJsi0/IxjqroA+yDfBHbxmQFoA86SsbOxN2/lhLvCxThSuKd1/8BW6AstyxhN+BeQ3YN4PfoZWp5PAXsgzIcM4Th6FBz5j27BkdwiM5Nxw1BH5FlDs6qAYTBjrzSF14IBzuu39c476oBJmTkt6VDfoT/zWs+GuFt2x24HuFrJdLaYeauQPF6qrQ2Nz9qHd3ZIdnOUrTRKi2/qeiRgMnuGfk1PVUpwNKULY1vAK8ghe0AG1n753mkucLaz7rmfaiUvsmX/CanTC1FFQpwDIrlUzaFjrO3P8knpwswHik0Jd3H+PyWx48FSRfrTTNkfWwGdn6VBLNuFLVvAhSLUdyBYhjJuHpfAU7wykeP5c1VQj4/PiQdUQdmyLqCV8dRfErcI7h0ZLRmoL59AMUFJBdx+BpV7AWUb3S8QAl85x5MN/BWW7UUoxGFv93at2MPp2Gvu+/pmc7ubGZ5/Kzlmac57K2FItaNRiiAHft/Va9UKuEwkbvuPsIecr6UIZv/NhNJhI5r6XcZNEIBbL+Al51SbszgzH2R7OhbEbal0rVCp509PfI7xNqf5ZRqEeqrAMKqwE+so1ML5GBW312AUzzS7GftZzlqbo3kxiyyfQYe8ChDJ6L8ZNA2JG30SxBrSjjbEniclf79SKnSrjnGkp9qnXdZAv+TWrPomULzb67Xd29iqpgLOCrjqVkZ3cnbGD3ks7nScyyvUVyBcBY6/Bzo/sOrCFsl+gjC6SSHnT7r7foADyOciopeLaNtFT8CxlqyP/Mue6ehOqfQ67Bn53T+ebOBO6XkNx89c/cswieO80878sqaDZQon4W4/QPyIpt0UjquAJ8hGTOBfv4Ap6T8KGl/dyIOn/ukAtzpmd9U3DOgywDCTQV/8I8QXozSnY45G+fO33TKSI+yqX+8hTnXXkKa+7nOY6Alvz3CGZGSpv3dSDHzdVPT2l9EWB49Hz8UPbwcgA7X8iTaZj8FVSLahtADOBYd22hd9EjlQWBicGMPBAKBQCDQGSjRCZR18J+IAR3c6TVQTbzmPVAAOdtvuXtimwhyKUhLO1B0Nuq5NGyHaDsE5EBQ/6rjtWuIDEK7vm9BfGnadGAyqHSn1eLX6grsZhyYDKpuMQXbC1G2BrC3qt7y2SBkFZBxHt/zVyA+09Y+1+xn5Z36ZrMaklCAQ0HWcmzrgmwEsifIZY4bMy/S6BZEBoPMKqDsz4Nk+SL6XrdyBaiiCViUUQ29iXa0vBfkMeAG41xftAXvYVfCdGQQsFq08y6oIg4lFSC90FZGM7RrG3r9wdPoN6ftDLFlY4OBcSA7gmrZSKcRiRoga6GFnfY+K22JFyXIJCN9bpTw6pEx1neYAdLHIbclyGJL1s8DOv3aldcA9XYJszt+vk6YTYKsR9zHYA4wHNRbSVk1leSb0seCOF9H2yjqrQC9rP25db5+R7Gf4AtBLUoXVxOBS62DTRUVpY7DQOlCch1d/kKM5mITa98VHMvmVuBkY38g8FBlJQJAVkYvt/sm+k1u7wHPAc8DU0Clhr+vkwJIN/RSajPC6KOgnq3P9SvDXAf4KKj30gQN7OVmFb8fUIYB40m+hKKdmSCHgHIue6tCAYaCuF7s1BW9Jn8D4DCIOYK00cAXJZVDuhF/Q5pvSFlbSTaspjyA9ooemiOzMTAd5GhQ4+yTVSjArwvKzwGGgvJ+eUSTYDu1+juz1g7zx28fis5HNwNDLNlr9KhJzTUPNmJhSH/gXG0saik+sPZ9Xwlrf89aOJNeAfQFtS+oE0Ftg/bGXmjJJeIaVaUAbSlbGsegq6X8pVhNg7Jvpm/Z7Zrj1QoKY3IRqONBLY4fVtOB7SzZI0FiazGrUIBdQPVM2RR6bcB2JH3qewOXg7SSX6LpWj4kGtnkYdsCqlSANvQbx1JQc0je91jTUIcmQH0I6klQJ5FcV7cryRvUzLxofO6NDnyRxzHW/nOVlQbGeoxELrf2YzVXnfsA6mbgT9bBhrw1uyT2uP+XIBnrA+RY4iOHa0FVWQP4rEy2F8PGIpo0ohNoT/5khWxpMtR9wP3Gga2AR0F6J2XlIHRIO5PRFRdobr6I+pz4yytjy/jqHSsYkgEVbPNws3MGcYvmEGAByAT0E7kSejbQXgDzV1AvUi120Iw0zNjGsRdSNUIB7Ce+6ptSY9Q0kP2Ba4lb33aNNhfngSMucsfxC64Rtz7Gmo06NwGyEskVu8WjeTccdQdakfPc2tqAA0GNjKriqvGIti62iTimAPWcDBqIfum0qY1twN/rV4YqUa9Hdvj+aKPLYHT7Ogf4N9oncHaNfvh2RgB/y5Gxg3DFOqFVKMDeIK61/6DDug1C3yBX9TjKc0KlSVFL0U/UK8BtDSjAISBnuv0RvuCH1n5ymXwxKnMKHQlS4g2ZjfYIaiQJjyABeSTdICXDLNl7bIlGDAMXAsNAje4E/nHNwAjgEhBjfC8KZC/gMUv2HDtxmSag6HLrOejl1dPQRolHQL2TnSRQkBP0JvPR09SDSfoH3AXqibqXrHpCE2Bsoz2b23EgK7hybOkwp8sg9ohiHHp+xZ6pNBkFHJ3mFtYIQ1CgNOpNkgt6XwQZj7ZODkS/ePsF4BlgJqjMJjsoQKdAfUQyBrMXrdgEmBod4vUEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAgEAoFAYFnj/z0NY6qGByEDAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with draw_target(128, 128) as canvas:\n",
+    "    paint = skia.Paint(AntiAlias=True, Color=skia.ColorRED)\n",
+    "    canvas.drawString('String', 10, 32, skia.Font(None, 36), paint)\n",
+    "    \n",
+    "    paint.setColor(skia.ColorGREEN)\n",
+    "    blob = skia.TextBlob('Blob', skia.Font(None, 36))\n",
+    "    canvas.drawTextBlob(blob, 10, 64, paint)\n",
+    "    \n",
+    "    paint.setColor(skia.ColorBLUE)\n",
+    "    blob = skia.TextBlob('Blob', skia.Font(None, 36), [(0, 0), (32, 5), (64, -5), (96, 2)])\n",
+    "    canvas.drawTextBlob(blob, 10, 96, paint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TextBlob\n",
+    "\n",
+    "`TextBlob` can be constructed with optional positions or geometric transforms. `RSXform` is a compressed form of rotation+scale matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAABHNCSVQICAgIfAhkiAAACVRJREFUeJztnX2MHVUVwH+72yrdClhg11gottZlQ9U0CrVIUwhILPELG6kGAYNiNWqMFlCMGDX1C41CxGCDYmqIBGxMA5sGtxt0jTHBEL+IFrLALoZuiA81JK+J3/j847yxd+7cmTf3vvl4H+eX3GRn9s6cM2/O3Dn33Dv3gKIoiqIoiqIoiqIoiqIoiqIoiqIoiqIog8ZI3Qr0Ia8CVrf//ivwZI26KDVwFGi1ywM169I1o3UroNSLGsCQs6JuBfqQB4Ez23//qk5FiqAoJ/DVwDZgql2mgX8AC8ASsAjcDzxbkDylR3gJcAfHnaJO5ZvAhlo0VQrnEvLfeLu8sQZ9i2ItsLFdJmrWpTYmgQbJG7sAzADfBg60t10G0ATOrlzrYhiobmAoM8Rv6BGkRXBxAvAlkkawCKwqXdPiGXoDOJ34jWwgLUIntpM0gtcFyN8MbG2XPHKLZugN4FLiN/GDHsd+xTr2/QHyzeM/GXB8twyUAYQEgjZb2494HHuvtf2aAPlKgYQEgk6xtjcAv8x57BHgx4bcRoB8pUBCDOB31vZngJ+S72b+B3hTgEwlndci/tB6JEJ5DFgGngF+RgmjlVMknbmjwMeQPnLZqA8gXAL8guS9sMsccF6RgkeAn2QIPALcAlwGvLRIwW3UAOBiOt94u2x1nSjkFdACdgLzSPNjs6ld9rS3l4CfI4Moh4G/BMgM5RxgpbG93C79zBnAfda+xxFjjGIrm4BrrDozSOi+ME4DbsPfEmdI9iR8yNsC7HXIfnMXciPqbgGuJH5N38EdUJtAWmOz7voyFDoNuBq4Gwnx5jWEqwPl5TEAO95Q1M2H+g3gFuLXtSaj7lusum8rW7kxZM7ce4E7if9YrnJ+gIwsAxgBvuaQc2mAnDTqNoC7kAet2f47i3OJ/w67ylXNzTTSQ3AZQwP/OQlpBjBC8ulokT5GEUrdBpCXU4B76AEDiFiBxAzsG/QKz/O4DGAEtz9yYddaJ+k1AxhHxlQuB64HvgUcwv067toAdgKzRnH1Ajpxn6XUOzyPtw1gFLid5MVuC9AtD71gAKOIlz9P8rqzSsIAfLuBLWCHsX0Q+I3nOQ4jMYKIac/jTcaAfcAHrP2vJ394ut84Hfgh+Qx8CXh5VgVfA/iDtX0h0g3x4URre8nzeJMvO/Yt4zdA1U+MIY6fffOPIWHfR4GngMeA3yPdPt8HtKMCdrOSaWEOHraOn/I8Pk9T9wXPc/pgznKaKVGOi124m/W0B/k8R92usWcDNZCIWydGgd3WsU38h6Tzvu+6CTb1KjcTv8Z3daj/UUowgHW4PczduAeDViI3wzV+cEeAfPscRxE/4nvW/l8zeN89HCJ+jVlBIEg+rIV1Ay/H/dRFT/U84iCmTQqNms8XBMg2z7GAOEUgoU/bMG8IOH8vY/frs7rQ7yH5mxcaB/gQfqFfs8wRPiHUPI8dCbzGIcs3ztDLfIL4tc2SnJo+gXsSbgt4X9EKnQrcmiLMVQ4gQ5ndfJOYZQCjJMfI57uU10tswv27ziKv06wWN/LX9lFCjGQt8AakP/5VJNhzEAnN7kGCPUVNFskyAIBXkrzw3QXJ7gWuI/8DtwsxDnv/RyrXukA6GQAkm8Amx32FfmcUuJbs1+9BjnfPz3fU/b8B9OMKIS3j7xuR0T+bcaQ5PMPYdz/w9hL1qpoJ5FuLTcjMqwbwNPLE/8mqOwlsQXoNzyJR0mZlmhZMnhYAZPy/VC9YqQezOdvToe4B4gbQYHAcQkVRFEVRFEVRFEVRFEVRFEXJQz+MBm4FLjC2H0ImfShDgv2Z9631qjNY6MjYkKMGMOSoAQw5RX04ofkChpQq8gWoE9ijVJUvQA2gREJfAZPIolA2jyPN/jKyeNRm4CxHvR8h/fvHAuV3YgXu7+b+XJK8oaPKfAG+LcAJDv2iCaH22gRKAFXnC/AxgFUkv6BtIRk+bwA+RdgHqYpB1fkC8hrAOO7PoBrIqyba9l3QYqAZlHwB48j3iDus/cvIKhmmr7GuIJkDwSDkC1iNvPMvtvYvARchn0s9gRjDk8C/C5A51FxB0gEsdBFii6xXwIuQhahdDmaVH4OuAT4O7EdaxEiHeWRtxM30x8hrLqrOF5BmACfhXi9/gXKWqU9jms7f5UcGUdR6xbVSdb4AlwGcjMwLcMl2tUYTSMRyjs7r6/owhf8qKXcxAGsXnYQswpTngheRpvFKJDjki20Ad5Ncai4qaec/1ahTZJ6ib1jyG8jn6hchcZHP424dritQh9qoKl+Aa93/tGI7giZmvSJiAauIP/2LwIsd9caADzt07bTCV99Qdr4AHwNYRLqELh4x6hWRwHoN8oQ/gFx3p+vZZ+k6kPGIMvIF+BhAC1mjyMVBo84FKXXK5FrienazRnJf0W2+gDQDmEVCya7/bXGcx3xfX9XNBQWyn7iOL6tBhwRVeKML7XI7Eos31/GdRNKw++a2uxdZE/CfiIF81vr/95Eo47+MfU8Zf6/3lJfGOmTRzClkPaL/As8ho47PIWMQTeCtwLuN444hAaq+o458AXYLcAh51USMI+9+uxW4yTrPZcb/7gzQ22Ql7hwFectsl/ILI2Sh5h1GOTdA5mFr2/dd+ATwvLH9N2TVUpsvAmcb2+YTt9FTps0PEM8+lIe7lF8Y/Z4vIGIOWRDqndb+7yI6Po/4IBHdLB+73SHnUeS1FMlYgwSrXgj8HZkBZa7O+dsu5NdKHfkC8g4Hr3Xo1iK+Kqa5f6V9gpzYztw9yI3OYqC6gFXnC/CZEOIKuJget5lIcX0OnV2Y8YQWnVuTMeI+SpM+HxiqOl+AjwGswB2ijpI7mQ7o9hyyXdjd2bTAU4S9tH7POIDdUGW+AN85geekyLuKeF7B0FjAnHXeKzLqriaZvnVvoNyeo6p8ASHTwl0JJJvAp41tu5uYl+sd595L3LkdQxI2NBx1dwbK7UmqyBdwk3WOm3McczLuH38/0jJ9neyBoyxOTDl3E3nNPUT2g9FTDmBRzshapM+9sV2mkajYH5F35tPID/NMQfLqZgPwIJ1v5jEkKmjWOwuJZSh9ziQy3SttwOtzSDzA7vmYTqkyAIwird42pGdxJvEA20bcDrAyRGxB0r1GvsGN9aqjKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKIqiKEq/8j8s5BNbAlfUvQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with draw_target(128, 128) as canvas:\n",
+    "    paint = skia.Paint(AntiAlias=True)\n",
+    "    \n",
+    "    blob = skia.TextBlob('Skia', skia.Font(None, 36), [(0, 0), (32, 5), (64, -5), (96, 2)])\n",
+    "    canvas.drawTextBlob(blob, 10, 48, paint)\n",
+    "    \n",
+    "    xform = [\n",
+    "        skia.RSXform(1, 0, 0, 0),\n",
+    "        skia.RSXform(1.2, 0, 28, 0),\n",
+    "        skia.RSXform(0.8, -0.1, 48, 0),\n",
+    "        skia.RSXform(1, 0.2, 64, 0),\n",
+    "    ]\n",
+    "    blob = skia.TextBlob.MakeFromRSXform('Skia', xform, skia.Font(None, 36))\n",
+    "    canvas.drawTextBlob(blob, 10, 96, paint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To build a `TextBlob` with multiple runs, use `TextBlobBuilder`. On drawing, all runs share the same `Paint`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAABACAYAAADS1n9/AAAABHNCSVQICAgIfAhkiAAACKBJREFUeJztnH2sFcUVwH9cH0RURMQ8LaD4BD+wlgZUqE+xiRIjfiFpidZKS7+EthpF/LZVwfgZa2NQiV8xUfGjaSqhtpCmtoklbWNDG5u+qphHC9TKRU0UGk0R+/zjzMmcu3fv3Z17dy/XZn7J5u2dOTt7zu7Z2dl5cw5EIpFIJBKJRCKRSCQSiUQikUgkEolEIpH/T4YFyo8GLg6QHwTWuf2ZwAnAu8CzgecNpQL8L4dcPzCthfZfADa3cFw75LWpVI4GhgK2n5hjl7mygZJ1nAb8AZiaQ/YuwuzRbU7hWjcnxKYgeto4djvwTobMljbab4U+4M8B8tuAv6eUH2v20+p3hCjVJqE2lYrtAS4MPHY88AXgc0UrZbD6tfO0VF0bDxWhVJsUZVMq7fQAobzptkgXUengub4CrAF+bMoWurJvufoBpHtdCUxxMscCjwKvI0/BVnfMpdQ68PXAI+b3g07uhGLNSGUCsAJ42ek4CDwHzE7IfdnptIb0HvQMUz+fPWtTKu28AtIGgXe7Mr25dutHDG02GFsP7OPaWt1A5uxAPSHsFTAXcdpGOv4I/7U1GnFgrTvMtHOIaWcQ2L9gmwrBOsD3gc802UYmjm3mALo9g1z0l5CL9hL+gsxALuBMpIfQYy5wbR2K3Awtnw8cB+zbgp15HWCCOd8g8nVwEPKuXmXq7MNysin/pbOz4va1/PgSbCqEkM/AxYljsxzghoT8cFP3vZS6QeSJuaOBfp0YBD7h5HYA4xJ1w/A3tQrsbeqWGz0vRh4m/X1Fop1SB4GhlOkAB6WcbxD/3j8X391D+gC20w6gXfbtDeovbKDPCGAD9dfsBeon57r2K+BGZEDSiJAR/07S5xQeQiZrJphzrQV+4bZ/BpyjaHqBUW7/S8DkFJmxZn8S8Fe3vwu4CHjN1G8HvoHc6I7RjgNsAv5WkB5vNCi/G/gAecL0Ys9x2/3A08Ai4D8F6RHCRLN/lNvyyoMMfJ8H5rnfa4G3i1EtP52cB2jGx03q7gceA76IfCbNBY5wdRcBY4CzStUuHTsbeAfwuwz5jYnfs/E3H+DrwFPAr9tXLT/d4gBpVJCufxJycde57UrgGGSUPR3pDUYD73dYv3+Y/XeQJzjJ3sjM5zbgLVM+FtEfZKq5B+lBViHzHu8WrWwjOjkRFMppyH/cfoNMoFheQ3oF5UD31/YkdtRdBrvw7/Ql1A5QlZuRyaEtiD3KSmQMAfIV8FW33+vqLJ20KZOyJoJeTpEfac41CJwI7GX0GMBPIinjzTE3IxMtrVy0vF8Bc6gdwetNHYEMDK3++rAtMOU3mbZuM+ULSrCpEDrpACBTxPYzaQe1M2lD1PYOPYm6IeCSQD0hbCbw0cT5XqF+ZlAndvoSciNMOyOpnRHtK9imVEJfAbY7Cv1c0cUMu1PKGg0CH0O6yE3u9yhkXADyL9KTgJ8a+d3IgHC7KTs6UE9LngUY30b+j/Ev93sq/ovl58DnkW9+qHWohchrRPkQGQiSkC3aphpCVwTtKSrIXPl4xFleRS5YMw52x1Xp3EqaMcjN+RAZv7xXcPt7wqZIJBKJRCKRSCQSiUQikUgkEolEIpFIJBKJfPrYK1ukbXqAI5FlTDs7cL5Il3AE8CL1S7qeQFbxftpptpRN6UHiFnoz5Fql7PZb5jj8urg1wK3Ikmcte50uVDqQPA6gax4nlaRD2e23zArSgzor+Lw8SzutVMHkcQCNYi7rBpXdfstoXPsZKXW9iIMsTJRPBX6GrHeruv20YMh+4GFkdXAV6WGScrOQyFxtazX12cBWI0uxzwV+hfROG4DLqV8rOQ9JeLUDyUlwHtkOsALf421Anta8ti5257GRzwDXufLFGe3vcRbh3/lX4bN9NGI2fpywgdrY+lON3DRTvgo/xtiKz0cwz8g8g9w4/W0TK1SpHZusM78XGbkzjczj+CwgWQ6wDL+EfR0+/D2PrWOMfhpQMsvYekCT9ruCHuABageAVWQN/dnULkcfjl8Pb2/Q8fj18/q1ogbPMHJXu7KrkMGlPhX2iT+FekfRC7zM6QDSYw0hiSlAon20PV2nX8HHAoS+AkJsVV0GkdXAavvJTdrvOk5Humv7tA0h3a+unZ+OfxqSaIaQyUgChiEk945lHyTBQj/yBA0h3WOSJ13dTPdbdUrmHLDRRtrj3JtoS6N1Qh0gr63Kg/jeZwi4JaP9YMqODXwRiWI5BAl6XIrMBczFx/ZppO90xMvtNsvVHY7P3afxeMoHSG/ze2S+AeAvKbroRbcXeLs7XtntyjRo9rPubzJX4Ju0NqeR11blGiTgZBRi920tnLMpZUQHj0Ni2zYi8e8gXvqq255GImXnI5ND+zmZjchNTGMnPqHSf5ucW2PmPkqp0zIbmZSVV0B7h7TIpVaikfPaqozEz5n0Ie/+QnMIlOEAu4A7kXCu51PqtwF/QoI998eHWf8byZBhORx5J27Gh6JNTMj0IKnnNuMzbvRRj3aTIUkttLdJO+cEakO+85DXVmUl8vT/EUmyuZL6SOmuZD1yw+6h3sl0cKNd8ljqAyJBcgbpu+9Q5EnQ96GdSTzflS/HZ+2q4scYybZ0wFdFBlhJbPm+pr39jMzXyDcG0PkQfZXktRUkJlIHpMPx19Qm60623zX04w3ainzq3It8b+sFOMfIX2dkFyODOk2idJmR0xH/ADKPsBw/mNMcAbcbmW8C38Enm/quaSuPA+D0UYddAPzA2JDlALc6ud/is3/lsfUw/PXTMcsU/AOgr8O09ruGPmSSJhkqvR7p/i0VZNbQyr4C/JDaHqSCTNQkPy+tM/XgHUW3ASSK15LXAQCupTYs/T4nk+UAk/HOpyll8tiqcxJLEu2p82gK/rT2u5JexIOHZ8gNQz6xkjn3klQQB5tI4y+ZCvJePTi3ltm6TSY9E0gWY6lPnJnX1lbbj0Sy+QSbzSF++UsmewAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "with draw_target(128, 64) as canvas:\n",
+    "    builder = skia.TextBlobBuilder()\n",
+    "    builder.allocRun('First Text', skia.Font(skia.Typeface('Arial'), 24), 0, 0)\n",
+    "    builder.allocRun('Second text', skia.Font(skia.Typeface('Arial'), 18), 10, 30)\n",
+    "    blob = builder.make()\n",
+    "    canvas.drawTextBlob(blob, 10, 32, skia.Paint(AntiAlias=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Runs in the blob do not contain text itself, but only glyph indices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Run([41, 76, 85, 86, 87, 3, 55, 72, 91, 87]),\n",
+       " Run([54, 72, 70, 82, 81, 71, 3, 87, 72, 91, 87])]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "list(blob)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Multiple runs with geometric parameters requires explicit conversion of text to glyphs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAABACAYAAADS1n9/AAAABHNCSVQICAgIfAhkiAAACL1JREFUeJztnHnMFEUWwH/fOBBBCCIELxQ/QRFRDLK7Kp4xeOBN1KgIiiKKewSP3fVeV4wajUoIKvGKiYqoIUoQhBiPxPv6VIyoYD6PZdl1UDe7kKy7yu7nH6+Ket1TM90zUzMfYP2SznTXq6muqn796uh6BZFIJBKJRCKRSOTnRVuANPoBk2qIXwQ2AN8Bjwe4fxYF4P81xB8LjK7jPouBr+r4Xy3UWpaWMBzoquFYoX6bzWjgDWBUDf+5ldrKY4/xwXLtp56yZFIMmRiwFvg2I86/At+zEu3Ae3X872vgY0/43urcJ19Xx73yUm9ZWoK2AGfmiL8zcCCwbzMzRTJfId6akknr3gBp1UrosmwktAXIwxpzRDYBCt1wz7OARcCsCvIpRj7VxF2BmNe5wAgTZ2/gAWAl8lasNv/5LaLUVwH3qzTvMfJfhCtGGYOBOcDbJk+dwBPAOE/c00x+FuG3mkcr+TxaX5aaqLUJuIHqncDbjNw+XH2MRQperTP2KvBMBdnxtRZOUa0JOBlR0kp5uoPkiKsforRWvquS7aDS6kRGF6HLEhStAL8Bdqxy9CK/AthjPlLpLyOV+DKucn6FVOYBiIWw//k18lDs9enAPsA2DZSzkgIMVvfpREYDA5G2ep6SpV+Og5XsWVO2gjm34WOAXZpQlqDUMgycTm0KcHVK1oPkQ07LOpG35xZa1wl82ISvA3ZKydpwD7QEbJ2Sz1R5nIS8QPb6EhWvaZ3AEDRTAQZ65J24dv9EoLeS6U5tqxTAmuubK/zvzCr56Al0UF5Pi0k2GZvNKOAapINSiTUkNbsa6/HPKdyLTNYMVvdaCiwxx5c50w/BIKCvOT8VGOaJM0CdDwU+VNc/ABOBT1XYWuA85GE3ndAK8DnwUaC0PqsQfhvwb+SNs5U/3hx3AY8BFwXKQxZD1Pme5sgb37ISeBqYYK6XAt80nrV8dMc8QF7+V0V2F/AgcDgyZDoZ2N3IJgL9gUubmjtBz/7dArySEX+VJ2wc7uEDnAs8CjzfWNbysSkrgI8CYvqHIpW9zByXAXshve79EWtwXQvy84U6/xZ5e9Nsjcx6fg38PSUbgOQZZHq5iFiRechcx3chM+ujOyaCGuFI5Ivbi8hkiuZTxCpY+qrzdO87FD/g2vRLSXZILdcjk0N/QfKvmYv0I0BGAWeb80FGZtHWsFllqZtmTQS97ZH1UvfqBH4JbKXyYb80rkS+Odi41yOTLY1UXqVRwHiSvXf7QHsiHUOdX/3CTVayP6nwm1T4ZBMWuixBaaUCgEwR6yHTOpKzal2IdSimwrqAC3PkrxLVZgIfSN1nOeUzg2NU/PZU3J5K1ovkLGh7E8qykRBNgDZPeYYudkHDhgx5pU7gg4i5/Nxc90X6BSCfTA8CFpj0j0OGVZbhOfKXhW9BxgXId4u/mutRuCboGWA/ZLxv0Uo0BWlKLN8jHUEdt1llCbIiqLsoIPPmOyPK8glSeT62N/FLNH9FTX/k4XyP9Ff+GTj9VpYlEolEIpFIJBKJRCKRSCQSiUQikUgksjmzVXaUTIrAHsgChfUB0otsJuwOvED54oyHEW+dyBbMPrgVL4uAG5GFjDZsJW5pVGQLZA5+96wCboeNy1udqZ8ZRcT/oVtetIXIQz7aIxuEKMiUVmYoxUJkceWJwHOIZeoAZhBmFZR2+qx2LA5wr0rYtZNDG0mkXr+ApYgzxgLEwXEJsiQLZN3a7xrJVAAOQvIH0jF9HTgG8Rn4D/l2+egC3kE8kNN8QHLZ+XBkPf8qpPmzvFtTrmujb3aU5lEE7iap7SVkdezxdL+/gV3BewPiNQxirboQ9/I8VFuZnOYiE78V3kggFtb2tzoQa1AX9T6oDYgr8zhk94q1iOmfipi9p3AaOspcl8zxFH4P17HAfcgS7xLSuWzUE/ZW4Edz/qL53b7BNOshbx2AeFC/iriaaa404dOBf+A22/qG8AtPa6YN2b7lMpxmPokoiLUQHSTbzsPU/0er8Hm44eVqZJ285lDE595W5kLK9/WzsjQlxEEjzQST33VIJZ9EOAuQtw4s/XEWzHoSHYqrj21NmN0Qo6E+QD3sBFxB0qFRswOugKvMr97OZAzOIcJORFnHDt3e/sGE/V6FTVBpz0cemr3W96j0oH3hx+LmMB7C7fETQgF64Jw8supAY5urTsRi2fo5WMXpNgUYqDJXCV2JHR653eZlGKJQXciGSpreSDMz1lz3w1kX/cYfQrm1yKsAvVWa7SasgPP0aVQB9idfHfi4B6eYXcCfU/JuUwAQM9kF3E75SEJrr1WC1anDho/DmchrMu55mIk3xyN7xMgOMNd5FcA2PXem4llfvEYV4DTy1YGPPireclxn1hJEAeodBv4Rccu+HDgD0eYSMkN4lImzCNkNZBUyDPOxHrdD1n8z7rmH+X3fI+tA3MWGAW9lZ38jI81veufPNYT5rtHH/GbVgY9euCn1dqTtD75xRL0K8Dri7zYbOALZlMHyGs5V+hLgb8iWJ5rdkLbvK5w/4RBP3maZOLfjvGF/pBwbVsnfsBLWndvnhxhiS9svzG9WHfiYi4yk3kR2Vp1L0iXelnWT8BIehIwCtJkaQNLD1TIQ167tgmi5bev0R6RTTPhMc32Cudau1JY7jWykR1aNA/G3r9Ybt9EmIG8dpJmEm7PogWty9a7sN5qwl8i/71LLuRLX/k1HOnV2Vyw9W2h7/CuQKeSZuKHQdiaO3Y+vRHIWTFdmup3MYhuVZh8Vfg7hhoF568CyK648toM4AveS2CZzGK6f1cyNqhuigHww0r7yy5HtW4qpeDNUHPtQTkildzNOUc4HpuEq4eI68zgd11OfDFyr8pBXAaaZ+DM8srx1YFmGX5msIi1LhQ+gfK5kk6MN6VmnN1JMU0BM5RD8s5RFnLWwxwrEP78RriDZM5+NKFZeBchD3jqI5KCAdKJCTuu2IWbVt89PJBKJRCKRSCQSiUQiWwI/AU8bINMnVJAMAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import random\n",
+    "\n",
+    "with draw_target(128, 64) as canvas:\n",
+    "    builder = skia.TextBlobBuilder()\n",
+    "    \n",
+    "    font = skia.Font(skia.Typeface('Arial'), 24)\n",
+    "    glyphs = font.textToGlyphs('First Text')\n",
+    "    xpositions = font.getXPos(glyphs)\n",
+    "    xpositions = [x + 5 * random.random() for x in xpositions]\n",
+    "    builder.allocRunPosH(font, glyphs, xpositions, 0)\n",
+    "    \n",
+    "    line_height = font.getSpacing()\n",
+    "    \n",
+    "    font = skia.Font(skia.Typeface('Arial'), 18)\n",
+    "    glyphs = font.textToGlyphs('Second Text')\n",
+    "    positions = font.getPos(glyphs, origin=(0, line_height))\n",
+    "    positions = [\n",
+    "        skia.Point(\n",
+    "            p.x() + 3 * random.random(),\n",
+    "            p.y() + 5 * random.random())\n",
+    "        for i, p in enumerate(positions)]\n",
+    "    builder.allocRunPos(font, glyphs, positions)\n",
+    "    \n",
+    "    blob = builder.make()\n",
+    "    paint = skia.Paint(AntiAlias=True)\n",
+    "    canvas.drawTextBlob(blob, 10, 24, paint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Font and Typeface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Typeface` specifies the typeface and intrinsic style of a font. `Font` contains `Typeface` and control options applied when drawing and measuring text, such as size information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Typeface('Arial', FontStyle(700, 5, Slant.kUpright_Slant))\n",
+      "Typeface('Arial', FontStyle(400, 5, Slant.kItalic_Slant))\n",
+      "Font(Typeface('Times New Roman', FontStyle(400, 5, Slant.kUpright_Slant)), 24.0, 1.0, 0.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "bold_typeface = skia.Typeface('Arial', skia.FontStyle.Bold())\n",
+    "italic_typeface = skia.Typeface('Arial', skia.FontStyle.Italic())\n",
+    "print(bold_typeface)\n",
+    "print(italic_typeface)\n",
+    "\n",
+    "font = skia.Font(skia.Typeface('Times New Roman'), 24)\n",
+    "print(font)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `Font` to measure various geometry of drawn texts. `measureText` calculates the advance of the text:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "35.98828125"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "font.measureText('text')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Recommended line height is given by `getSpacing`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "27.59765625"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "font.getSpacing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For detailed metrics of geometric measurement, obtain `FontMetrics` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "FontMetrics(Flags=3, Top=-24.1641, Ascent=-21.3867, Descent=5.19141, Bottom=7.35938, Leading=1.01953, AvgCharWidth=61.6406, MaxCharWidth=61.6406, XMin=-13.6406, XMax=48, XHeight=10.7344, CapHeight=15.8906, UnderlineThickness=1.17188, UnderlinePosition=2.61328, StrikeoutThickness=-5.38825e-33, StrikeoutPosition=4.59163e-41)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "font.getMetrics()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On drawing, texts are represented by `glyphs`. `Typeface` maintains character to glyph mapping. Unicode texts are mapped one-by-one to glyph indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[87, 72, 91, 87]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "glyphs = font.textToGlyphs('text')\n",
+    "glyphs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`glyph` positions and bounding boxes are given by `getPos` and `getBounds`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Point(10, 10), Point(16.668, 10), Point(27.3203, 10), Point(39.3203, 10)]\n",
+      "[Rect(-1, -16, 8, 2), Rect(-1, -13, 11, 2), Rect(-1, -12, 13, 1), Rect(-1, -16, 8, 2)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(font.getPos(glyphs, origin=(10, 10)))\n",
+    "print(font.getBounds(glyphs))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Glyphs can be converted to `Path` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<skia.Path at 0x108cb6c70>,\n",
+       " <skia.Path at 0x108cb6cb0>,\n",
+       " <skia.Path at 0x108cb6cf0>,\n",
+       " <skia.Path at 0x108cb6d30>]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "font.getPaths(glyphs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FontMgr\n",
+    "\n",
+    "List of available font families can be retrieved by `FontMgr`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Abadi MT Condensed Extra Bold',\n",
+       " 'Abadi MT Condensed Light',\n",
+       " 'Al Bayan',\n",
+       " 'Al Nile',\n",
+       " 'Al Tarikh',\n",
+       " 'American Typewriter',\n",
+       " 'Andale Mono',\n",
+       " 'Arial',\n",
+       " 'Arial Black',\n",
+       " 'Arial Hebrew']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fontmgr = skia.FontMgr()\n",
+    "list(fontmgr)[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each font has specific style presets. For example, `Helvetica` font has 6 styles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(FontStyle(400, 5, Slant.kUpright_Slant), 'Regular'),\n",
+       " (FontStyle(400, 5, Slant.kItalic_Slant), 'Oblique'),\n",
+       " (FontStyle(300, 5, Slant.kUpright_Slant), 'Light'),\n",
+       " (FontStyle(300, 5, Slant.kItalic_Slant), 'Light Oblique'),\n",
+       " (FontStyle(700, 5, Slant.kUpright_Slant), 'Bold'),\n",
+       " (FontStyle(700, 5, Slant.kItalic_Slant), 'Bold Oblique')]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "styles = fontmgr.matchFamily('Helvetica')\n",
+    "list(styles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once a font family and a style is determined, `Typeface` object can be created:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Typeface('Helvetica', FontStyle(700, 5, Slant.kUpright_Slant))"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "styles.createTypeface(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, `FontMgr` can look for closest face."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Typeface('Arial', FontStyle(400, 5, Slant.kUpright_Slant))"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "typeface = fontmgr.matchFamilyStyle('Arial', skia.FontStyle.Normal())\n",
+    "typeface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/Point.cpp
+++ b/src/skia/Point.cpp
@@ -126,7 +126,7 @@ py::class_<SkIPoint>(m, "IPoint", R"docstring(
     .def("__iter__",
         [] (const SkIPoint& p) {
             return py::make_iterator(&p.fX, &p.fX + 2);
-        })
+        }, py::keep_alive<0, 1>())
     .def("__len__", [] (const SkIPoint& p) { return 2; })
     .def("__repr__",
         [] (const SkIPoint& p) {
@@ -546,7 +546,7 @@ py::class_<SkPoint>(m, "Point", R"docstring(
     .def("__iter__",
         [] (const SkPoint& p) {
             return py::make_iterator(&p.fX, &p.fX + 2);
-        })
+        }, py::keep_alive<0, 1>())
     .def("__len__", [] (const SkPoint& p) { return 2; })
     .def("__repr__",
         [] (const SkPoint& p) {
@@ -665,7 +665,7 @@ py::class_<SkPoint3>(m, "Point3",
     .def("__iter__",
         [] (const SkPoint3& p) {
             return py::make_iterator(&p.fX, &p.fX + 3);
-        })
+        }, py::keep_alive<0, 1>())
     .def("__len__", [] (const SkPoint3& p) { return 3; })
     .def("__repr__",
         [] (const SkPoint3& p) {

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -501,8 +501,11 @@ def test_Font_getXPos(font, glyphs):
 
 
 def test_Font_getPath(font, glyphs):
-    path = skia.Path()
-    assert isinstance(font.getPath(glyphs[0], path), bool)
+    assert isinstance(font.getPath(glyphs[0]), skia.Path)
+
+
+def test_Font_getPaths(font, glyphs):
+    assert isinstance(font.getPaths(glyphs), list)
 
 
 def test_Font_getMetrics(font):

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -168,9 +168,13 @@ def test_Typeface_MakeDefault(typeface):
     assert isinstance(skia.Typeface.MakeDefault(), skia.Typeface)
 
 
-def test_Typeface_MakeFromName(typeface):
-    assert isinstance(
-        skia.Typeface.MakeFromName('Arial', skia.FontStyle()), skia.Typeface)
+@pytest.mark.parametrize('args', [
+    ('monospace', skia.FontStyle.Normal()),
+    ('monospace',),
+    (None,),
+])
+def test_Typeface_MakeFromName(typeface, args):
+    assert isinstance(skia.Typeface.MakeFromName(*args), skia.Typeface)
 
 
 @pytest.mark.parametrize('args', [
@@ -197,22 +201,63 @@ def test_Typeface_MakeDeserialize(typeface):
 
 
 @pytest.fixture
-def fontstyleset():
-    return skia.FontStyleSet.CreateEmpty()
+def fontstyleset(fontmgr):
+    return fontmgr.createStyleSet(0)
 
 
-def test_FontStyleSet_unique(fontstyleset):
-    assert isinstance(fontstyleset.unique(), bool)
+def test_FontStyleSet_init(fontstyleset):
+    assert isinstance(fontstyleset, skia.FontStyleSet)
 
 
-def test_FontStyleSet_ref_unref(fontstyleset):
-    fontstyleset.ref()
-    fontstyleset.unref()
+def test_FontStyleSet_getitem(fontstyleset):
+    assert isinstance(fontstyleset[0], tuple)
 
 
-@pytest.fixture()
+def test_FontStyleSet_len(fontstyleset):
+    assert isinstance(len(fontstyleset), int)
+
+
+def test_FontStyleSet_list(fontstyleset):
+    assert isinstance(list(fontstyleset), list)
+
+
+def test_FontStyleSet_count(fontstyleset):
+    assert isinstance(fontstyleset.count(), int)
+
+
+def test_FontStyleSet_createTypeface(fontstyleset):
+    assert isinstance(fontstyleset.createTypeface(0), skia.Typeface)
+
+
+def test_FontStyleSet_getStyle(fontstyleset):
+    style, name = fontstyleset.getStyle(0)
+    assert isinstance(style, skia.FontStyle)
+    assert isinstance(name, str)
+
+
+def test_FontStyleSet_matchStyle(fontstyleset, fontstyle):
+    assert isinstance(fontstyleset.matchStyle(fontstyle), skia.Typeface)
+
+
+def test_FontStyleSet_CreateEmpty():
+    assert isinstance(skia.FontStyleSet.CreateEmpty(), skia.FontStyleSet)
+
+
+@pytest.fixture(scope='module')
 def fontmgr():
-    return skia.FontMgr.RefDefault()
+    return skia.FontMgr()
+
+
+def test_FontMgr_getitem(fontmgr):
+    assert isinstance(fontmgr[0], str)
+
+
+def test_FontMgr_len(fontmgr):
+    assert isinstance(len(fontmgr), int)
+
+
+def test_FontMgr_list(fontmgr):
+    assert isinstance(list(fontmgr), list)
 
 
 def test_FontMgr_countFamilies(fontmgr):

--- a/tests/test_textblob.py
+++ b/tests/test_textblob.py
@@ -7,8 +7,17 @@ def textblob():
     return skia.TextBlob('foo', skia.Font())
 
 
-def test_TextBlob_init():
-    assert isinstance(skia.TextBlob('foo', skia.Font()), skia.TextBlob)
+@pytest.mark.parametrize('args', [
+    ('foo', skia.Font()),
+    ('foo', skia.Font(), [(0, 10), (5, 10), (10, 10)]),
+])
+def test_TextBlob_init(args):
+    assert isinstance(skia.TextBlob(*args), skia.TextBlob)
+
+
+def test_TextBlob_iter(textblob):
+    for run in textblob:
+        assert isinstance(run, skia.TextBlob.Iter.Run)
 
 
 def test_TextBlob_bounds(textblob):
@@ -85,6 +94,10 @@ def run(textblob):
     yield run
 
 
+def test_TextBlob_Iter_Run_repr(run):
+    assert isinstance(repr(run), str)
+
+
 def test_TextBlob_Iter_Run_fTypeface(run):
     assert isinstance(run.fTypeface, (skia.Typeface, type(None)))
 
@@ -107,26 +120,30 @@ def test_TextBlobBuilder_init():
 
 
 def test_TextBlobBuilder_allocRun(builder):
-    builder.allocRun(skia.Font(), [0x20, 0x21], 0, 0)
+    builder.allocRun('foo', skia.Font(), 0, 0)
 
 
 def test_TextBlobBuilder_allocRunPosH(builder):
-    builder.allocRunPosH(skia.Font(), [0x20, 0x21], [0, 1], 0)
+    font = skia.Font()
+    builder.allocRunPosH(font, font.textToGlyphs('foo'), [0, 1, 2], 0)
 
 
 def test_TextBlobBuilder_allocRunPos(builder):
+    font = skia.Font()
     builder.allocRunPos(
-        skia.Font(), [0x20, 0x21], [skia.Point(0, 0), skia.Point(1, 0)])
+        skia.Font(), font.textToGlyphs('foo'), [(0, 0), (1, 0), (2, 0)])
 
 
 def test_TextBlobBuilder_allocRunRSXform(builder):
+    font = skia.Font()
     xform = [
         skia.RSXform(1, 0, 0, 0),
         skia.RSXform(1, 0, 1, 0),
+        skia.RSXform(1, 0, 2, 0),
     ]
-    builder.allocRunRSXform(skia.Font(), [0x20, 0x21], xform)
+    builder.allocRunRSXform(font, font.textToGlyphs('foo'), xform)
 
 
 def test_TextBlobBuilder_make(builder):
-    builder.allocRun(skia.Font(), [0x20, 0x21], 0, 0)
+    builder.allocRun('foo', skia.Font(), 0, 0)
     assert isinstance(builder.make(), skia.TextBlob)


### PR DESCRIPTION
* `Font`, `Typeface`, `FontStyleSet`, and `FontStyle` get `__repr__`
* Make `FontStyleSet` and `TextBlob` iterable
* Change some method signatures
* Add missing `Font.getPaths` wrapper
* Add text drawing notebook

* Increment version to v0.0.5