### PR TITLE
Disable epel repo in linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Print submodule commits
       run: git submodule status > submodule.txt
     - name: Install system dependencies
-      run: yum install -y fontconfig-devel mesa-libGL-devel xorg-x11-server-Xvfb mesa-dri-drivers
+      run: yum --disablerepo=epel install -y fontconfig-devel mesa-libGL-devel xorg-x11-server-Xvfb mesa-dri-drivers
     - uses: actions/cache@v1
       id: cache
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         submodules: true
     - name: Install system dependencies
       run: |
-        yum install -y fontconfig-devel mesa-libGL-devel xorg-x11-server-Xvfb mesa-dri-drivers
+        yum --disablerepo=epel install -y fontconfig-devel mesa-libGL-devel xorg-x11-server-Xvfb mesa-dri-drivers
         yum clean all
         rm -rf /var/cache/yum
     - name: Set PATH


### PR DESCRIPTION
Installing system dependency fails sometimes. To mitigate the issue, disable `epel` repo in `yum`.