### PR TITLE
Allow conversion between various numpy types and color types

### DIFF
--- a/notebooks/Python-Image-IO.ipynb
+++ b/notebooks/Python-Image-IO.ipynb
@@ -124,9 +124,9 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQYAAAD8CAYAAACVSwr3AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAVX0lEQVR4nO3df3BV9Z3G8feHYJIWlJ8hoqCgZYWAGjBLQUFi3bbodBfbTl36R0t33aEztbt22t0p6nTW7nS67ba2HWd27eLUlu62WqfWlXGUrb8SoAISNMZApCKiwPIjKA1IJ6Qkn/0jB71yCLkk9+R7zr3PayZz7z333HsfTsIz55x7zveYuyMikmtY6AAikj4qBhGJUTGISIyKQURiVAwiEqNiEJGYxIrBzBab2XYz22FmK5L6HBEpPEviOAYzKwN+D3wU2ANsBj7r7tsK/mEiUnBJrTHMBXa4+0537wIeBJYk9FkiUmDDE3rfC4HdOY/3AB/ua+bx48f7lClTEooiIgBbtmw55O5V+cybVDH0y8yWA8sBLrroIpqamkJFESkJZvZGvvMmtSmxF5ic83hSNO1d7r7S3evcva6qKq8SE5EhklQxbAammdlUMysHlgKrE/osESmwRDYl3P2EmX0Z+F+gDLjf3bcm8VkiUniJ7WNw98eBx5N6fxFJjo58FJEYFYOIxKgYRCRGxSAiMSoGEYlRMYhIjIpBRGJUDCISo2IQkRgVg4jEqBhEJEbFICIxKgYRiVExiEiMikFEYlQMIhKjYhCRGBWDiMSoGEQkRsUgIjEqBhGJUTGISIyKQURiVAwiEqNiEJEYFYOIxKgYRCRGxSAiMSoGEYlRMYhIjIpBRGJUDCISo2IQkRgVg4jEDB/Mi81sF3AU6AZOuHudmY0FfgVMAXYBN7v74cHFFJGhVIg1huvcvdbd66LHK4Cn3X0a8HT0WEQyJIlNiSXAquj+KuCmBD5DRBI02GJw4LdmtsXMlkfTqt19X3R/P1B9uhea2XIzazKzpvb29kHGEJFCGtQ+BmCBu+81swnAk2b2Su6T7u5m5qd7obuvBFYC1NXVnXYeEQljUGsM7r43uj0IPALMBQ6Y2USA6PbgYEOKyNAacDGY2QgzO/fkfeBjQCuwGlgWzbYMeHSwIUVkaA1mU6IaeMTMTr7PL919jZltBh4ys1uAN4CbBx9TRIbSgIvB3XcCV55m+lvA9YMJJSJh6chHEYlRMYhIjIpBRGJUDCISo2IQkZjBHvkoRWh9SwttHR209fTwyogRvF1ZyR8rKjh03nn8sbKSjlGjABjV0cEHOzsZf+QIHzx+nLGdnUw/dowZw4ZRM2oU11xxReB/iQyUikF49sUXaezoYN2oUWydNIkDef6H7hg1io5Ro9hX/d7pME/kPF/d3s7MPXtY2NFB/ejR1NfWFji5JEXFUII6Ozt5rq2Nxo4Ovjt/Psdnz07kcw5UVXGgqopngG8CFcePs2LDBupHj2be9OlUVlYm8rkyeOYe/vyluro6b2pqCh2jqPX09PBMczMPHTvGIzU1HBo3Lmie8W+9xae2buXmkSO5rraWYcO0uytpZrYlZ9yUM8+rYihuPT09rGtpYekFF7B/woTQcU7r/IMHeWjfPq65/HIVRILOphj0Wyhijz3/PNe2tlJfW5vaUgDYP2EC1155JYtaW3li8+bQcQTtYyg6M3bu5JVLLul9MHdu2DBnaf0VV3BjzuPpO3fSdvLfIkNKawxFYvvOndzQ1PReKRSBVy65hBuamnh99+7QUUqOiiHjjh49ym2Njcy66CLW1OW1+Zgpa+rqmDFhAnc0NHD06NHQcUqGiiGjenp6+Mm6dUzr7OSeRYs4Mbx4twqPV1Twr/X1TOvs5Kfr1tHT0xM6UtFTMWTUR1pa+LuFCzlQVRU6ypA5UFXF3y5cyEdaWkJHKXoqhgxa+9JLNJbwUYSNtbVs3rYtdIyipmLIiO7ubpavW4cBi66MDZxVcubW1GDA8nXr6O7uDh2n6KgYMqCrq4ubtmzhvoULQ0dJnfsWLuSmLVvo6uoKHaWoqBgyYPHWrTyWsWMShtJjc+eyeOvW0DGKiooh5doPHeLZhE5yKibPzp5N+6FDoWMUDRVDiu3Zt4+rjx0LHSMzrj52jD379vU/o/RLxZBSbx8+zKI//YkdF18cOkpm7Lj4Yuq7unj78OHQUTJPxZAy3d3dXNfczLgxY9h50UWh42TOaxdfzLgxY7j+xRf1bcUgqBhSxN353KZNNJTwMQqF8szs2Xxh40bSMKxAFqkYUuSbjY08cPXVoWMUjf++5hq+2dgYOkYmaaCWFCnr6aFHA5UU1LCeHrq1TAEN1JJJB9vbVQoJ6Bk2jIPt7aFjZI7+ElNgRUMD1SV0MtRQq66q4q6GhtAxMkXFENgLbW18X4c6J+5bCxfSpBOv8qZiCKinp4flQHdZWegoRa+7rIwvgcZyyJOKIaB71q1jy4wZoWOUjM01Naxcvz50jExQMQTy9uHDfOOqq0LHKDnfmDmTt95+O3SM1Ou3GMzsfjM7aGatOdPGmtmTZvZqdDsmmm5mdo+Z7TCzFjObk2T4LPvq1q28M3Jk6Bgl59C4cXxN+xr6lc8aw8+AxadMWwE87e7TgKejxwA3ANOin+XAvYWJWVzmtbayasGC0DFK1qoFC5jX2tr/jCWs32Jw97XAqeteS4BV0f1VwE0503/uvTYCo81sYqHCFotNs2aFjlDy9Ds4s4HuY6h295Pnt+4HTl7u+EIg9yIAe6JpIpIhg9756L3HVJ/1cdVmttzMmsysqb2Ejkzb0tYWOoJEdFxD3wZaDAdObiJEtwej6XuByTnzTYqmxbj7Snevc/e6qhI66u97GisgNb7/hz+EjpBaAy2G1cCy6P4y4NGc6Z+Pvp2YB3TkbHKUvFd37eJhjd2YGg/PncvvX389dIxUyufrygeADcBlZrbHzG4BvgN81MxeBf4iegzwOLAT2AHcB3wpkdQZ9ZfuRX3FqKw5MXw4fxU6REr1+1fq7p/t46nrTzOvA7cONlQxat6+ne2XXRY6hpxi+9SpNG/fTq1+N++jIx+HyM/27w8dQfqg302cimEInDhxgl/OnBk6hvThwZqa0BFSR8UwBNa3ttI+fnzoGNKHA1VVNDQ3h46RKiqGIdCgr8VST7+j91MxJKyrq4vvzJ8fOob047vz5nH8+PHQMVJDxZCw57Zt43hFRegY0o/Oyko26KjUd6kYErZGq6iZoc2J96gYErZmok4uzYqG0aNDR0gNFUOCenp6aP3Qh0LHkDz9Tqdiv0vFkKC1LS0a6DVDdLj6e1QMCXrlyJHQEUQGRMWQoFdScPk/kYFQMSRoV2Vl6AgiA6JiSND+ESNCRxAZEBVDgjrPOSd0BJEBUTEkaP/YsaEjiAyIiiFBneXloSOIDIiKIUGd2vkoGaViEJEYFUOCRusAJ8koFUOCKnV+v2SUiiFB5+s0XskoFUOCRnd2ho4gMiAqhgSdr2KQjFIxJGjKiROhI4gMiIohQVN0fr9klIohQdM1VJhklIohQfNmzWJUR0foGJKn6vb20BFSQ8WQsFpdZj0zpu/dGzpCaqgYElavYxkyQ7+r96gYElav/QyZod/Ve1QMCZs/YwaVOp4h9So7O5k/Y0boGKmhYkhYRUUFt23cGDqG9OPrGzdSoUsJvkvFMATmfeADoSNIP7QZ8X79FoOZ3W9mB82sNWfaXWa218yao58bc5673cx2mNl2M/t4UsGz5BNXXcXId94JHUP6UHXoEAt0Far3yWeN4WfA4tNM/6G710Y/jwOYWQ2wFJgZveY/zKzkL8U0fPhwPt3cHDqG9OFT27YxXEepvk+/xeDua4G383y/JcCD7n7c3V8HdgBzB5GvaHxh5MjQEaQPS887L3SE1BnMPoYvm1lLtKkxJpp2IbA7Z5490bQYM1tuZk1m1tReAkec1dfWcsmbb4aOIaeYuns39bW1oWOkzkCL4V7gUqAW2AfcfbZv4O4r3b3O3euqqqoGGCNbnjLDdNm61DB3njELHSOVBlQM7n7A3bvdvQe4j/c2F/YCk3NmnRRNE2Dq5MncvGFD6BgSuXnDBqZMmhQ6RioNqBjMbGLOw08CJ7+xWA0sNbMKM5sKTAOeH1zE4vJPY8b0P5MMia/rgkB96ndXrJk9ANQD481sD/DPQL2Z1QIO7AK+CODuW83sIWAbcAK41d27k4meTVfp6LrUmD19eugIqWWegm3euro6b2pqCh1jyGirNh3C/+UPLTPb4u51+cyrIx8D+HBra/8zSaIW6biSM1IxBLBx1iz++rnnQscoWcvWr6dBX1GekYohkO9NmcK5R4+GjlFyzj16lLtrakLHSD0VQyCTL7iAO7ZsCR2j5PzLCy8wTt9G9EvFENBXr76amtdeCx2jZFz2+uv8w8KFoWNkgoohoPLycu4+fDh0jJLx444Ohg3Tn3w+tJQCW1xXxxfXrg0do+jd1tiocyLOgoohBX587bXs2rMndIyi9cbevfxo0aLQMTJFxZASF+uY/cRcdOFpT/CVM1AxpMhtjY2hIxQdLdOBUTGkyN0LFvCJ53XOWaF84vnnuXvBgtAxMknFkCJlZWX8+sor+fNt20JHybz65mZ+feWVlJWV/MiCA6JiSJmKigqer6nh/w4c0IhPA3DJm2/y1uHDPFtbq+HgB0HFkFITq6t5yowL9u8PHSUzLti/n6fMGKsxLwZNxZBiUydPplmjF+ftpXPOYerkyf3PKP1SMaRc1fjxXPfii6FjpN4NTU2MHzcudIyioWLIgDUzZ7JUp2n36TMbNvDYnDmhYxQVFUMGlJeX88v58/l2QwNl3Rop76Sy7m6+1dDAr+bN0zkQBaalmRFmxu319ZwoK2N/CVyHoz/729s5UVbGnfX1mIaALzgVQwZVV1Vxe0NDSV6j4uRaQnWJXIskFBVDRn27vp7ftbYyp60tdJQhM6etjXXbtnFnfX3oKEVPxZBh8y+/nM2XXcY9jY2cd+RI6DiJOe/IEX7U2Mjmyy5j/uWXh45TElQMGTds2DD+ftEitnd2FuUAs19Yv57tnZ3ctmiRdjAOIR09UyTOnzCBBydM4EhTE0/U5XXpgNRb3NTET3USVBCq4CLzeF0dTu/FVDa2tlKfoesn1Dc3s7G19d38xVJwWaQ1hiL24VmzeBZobG5O/bBmDc3NLEp5xlKiNYYSsKi2luNdXfx640Zu2rSJ8q6u0JGo7OzkMxs28D+bNnG8q0ulkDJaYygR5eXlfHrePD4NvPPOOzz14ousOX6c/7z22iHNsXztWhaXl/PRWbMYOX/+kH625E8XtS1xr+zcyZrdu1kzYgSNs2bRWVlZ0Pev7OxkUWsri48d4+OTJjHj0ksL+v6Sv7O5qK2KQaRE6GrXIjIoKgYRiVExiEhMv8VgZpPN7Fkz22ZmW83stmj6WDN70sxejW7HRNPNzO4xsx1m1mJmGkFDJGPyWWM4AXzN3WuAecCtZlYDrACedvdpwNPRY4AbgGnRz3Lg3oKnFpFE9VsM7r7P3V+I7h8F2oALgSXAqmi2VcBN0f0lwM+910ZgtJlNLHhyEUnMWe1jMLMpwGxgE1Dt7vuip/YD1dH9C4HdOS/bE00TkYzIuxjMbCTwMPAVd3/fyf/eezDEWR0QYWbLzazJzJraNVSZSKrkVQxmdg69pfALd/9NNPnAyU2E6PZgNH0vkDu4/6Ro2vu4+0p3r3P3uioN0yWSKvl8K2HAT4A2d/9BzlOrgWXR/WXAoznTPx99OzEP6MjZ5BCRDMjnJKprgM8BL5vZyZP77wC+AzxkZrcAbwA3R889DtwI7AD+CPxNQROLSOL6LQZ3Xw/0NT739aeZ34FbB5lLRALSkY8iEqNiEJEYFYOIxKgYRCRGxSAiMSoGEYlRMYhIjIpBRGJUDCISo2IQkRgVg4jEqBhEJEbFICIxKgYRiVExiEiMikFEYlQMIhKjYhCRGBWDiMSoGEQkRsUgIjEqBhGJUTGISIyKQURiVAwiEqNiEJEYFYOIxKgYRCRGxSAiMSoGEYlRMYhIjIpBRGJUDCISo2IQkZh+i8HMJpvZs2a2zcy2mtlt0fS7zGyvmTVHPzfmvOZ2M9thZtvN7ONJ/gNEpPCG5zHPCeBr7v6CmZ0LbDGzJ6Pnfuju38+d2cxqgKXATOAC4Ckz+zN37y5kcBFJTr9rDO6+z91fiO4fBdqAC8/wkiXAg+5+3N1fB3YAcwsRVkSGxlntYzCzKcBsYFM06ctm1mJm95vZmGjahcDunJft4TRFYmbLzazJzJra29vPOriIJCfvYjCzkcDDwFfc/QhwL3ApUAvsA+4+mw9295XuXufudVVVVWfzUhFJWF7FYGbn0FsKv3D33wC4+wF373b3HuA+3ttc2AtMznn5pGiaiGREPt9KGPAToM3df5AzfWLObJ8EWqP7q4GlZlZhZlOBacDzhYssIknL51uJa4DPAS+bWXM07Q7gs2ZWCziwC/gigLtvNbOHgG30fqNxq76REMkWc/fQGTCzduAYcCh0ljyMJxs5ITtZlbPwTpf1YnfPa4deKooBwMya3L0udI7+ZCUnZCerchbeYLPqkGgRiVExiEhMmophZegAecpKTshOVuUsvEFlTc0+BhFJjzStMYhISgQvBjNbHJ2evcPMVoTOcyoz22VmL0enljdF08aa2ZNm9mp0O6a/90kg1/1mdtDMWnOmnTaX9bonWsYtZjYnBVlTd9r+GYYYSNVyHZKhENw92A9QBrwGXAKUAy8BNSEznSbjLmD8KdP+DVgR3V8BfDdArmuBOUBrf7mAG4EnAAPmAZtSkPUu4B9PM29N9HdQAUyN/j7KhijnRGBOdP9c4PdRnlQt1zPkLNgyDb3GMBfY4e473b0LeJDe07bTbgmwKrq/CrhpqAO4+1rg7VMm95VrCfBz77URGH3KIe2J6iNrX4Kdtu99DzGQquV6hpx9OetlGroY8jpFOzAHfmtmW8xseTSt2t33Rff3A9VhosX0lSuty3nAp+0n7ZQhBlK7XAs5FEKu0MWQBQvcfQ5wA3CrmV2b+6T3rqul7qudtObKMajT9pN0miEG3pWm5VrooRByhS6G1J+i7e57o9uDwCP0roIdOLnKGN0eDJfwffrKlbrl7Ck9bf90QwyQwuWa9FAIoYthMzDNzKaaWTm9Y0WuDpzpXWY2IhrnEjMbAXyM3tPLVwPLotmWAY+GSRjTV67VwOejvejzgI6cVeMg0njafl9DDJCy5dpXzoIu06HYi9rPHtYb6d2r+hpwZ+g8p2S7hN69uS8BW0/mA8YBTwOvAk8BYwNke4De1cU/0bvNeEtfuejda/7v0TJ+GahLQdb/irK0RH+4E3PmvzPKuh24YQhzLqB3M6EFaI5+bkzbcj1DzoItUx35KCIxoTclRCSFVAwiEqNiEJEYFYOIxKgYRCRGxSAiMSoGEYlRMYhIzP8DRZpn7ltOAtAAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJQAAACPCAYAAAAcLfKMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAIKElEQVR4nO3dX4wdZR3G8e9joV7UqtTWWrC2mDQ2vSBSVqmRQFGblN7QK2wTFQ1JL8REojdFbxqv0AsNJMa4xkZIDGgiChcVxNoFarR2S7AtkKULEawptPVPxRj/VH5ezFsZt/tn9uxvzvueM79PcnLOzp7OPKd9OjM7e877yswIwcubcgcIwyUKFVxFoYKrKFRwFYUKrqJQwVUrhZK0VdKEpElJu9vYRiiTvK9DSVoEPA9sAU4Ch4GdZvas64ZCkdrYQ30QmDSzF83sX8ADwM0tbCcU6JIW1nkF8Pva1yeBa6c+SdIuYBfAkiVLrlm/fn0LUUJbjhw5ctbMVkxd3kahGjGzUWAUYGRkxMbHx3NFCT2Q9NJ0y9s45P0BWF37+t1pWeiANgp1GFgn6UpJi4EdwMMtbCcUyP2QZ2bnJX0OeBRYBOw1s2e8txPK1Mo5lJntA/a1se5QtrhSHlxFoYKrKFRwFYUKrqJQwVUUKriKQgVXUajgKgoVXEWhgqsoVHAVhQquolDBVRQquIpCBVdRqOAqChVcRaGCqyhUcBWFCq6iUMFVFMrRQeALwFXA5YDS/VVp+S/zReubbB9FHwa/AL4CPD7Lc06l2zHgG7XlNwB7gM0tZcslCjVP1+Gzp3kcuHHKep90WG9ucchr6BGqQ1hbh62Daf2PtLT+fok9VAOXAuf7tK2bgDcD/+jT9rzFHmoWq6j2Gv0q0wX/TNtd0+fteog91AyUOwDwMlWOQZo8JfZQU5ymjDLViSrXIIhC1fwRWJk7xAxWUuUrXRSqZnnuAHMoPR9Eof5nUe4ADZWeMwpFdYHx9dwhGnod+EjuELOIQgFjuQPM04HcAWYxZ6Ek7ZV0WtLx2rJlkh6TdCLdX5aWS9I9aUqOo5I2thnew9LcAXp00QDhhWiyh/oesHXKst3AfjNbB+xPX0N1oXdduu0CvuUTsx1jwN9yh+jRWaq/+NLMWSgzewL405TFNwP3psf3Attry++zyq+Bt0ta5RXW241zP6VoH8sdYBq9nkOtNLNT6fErvHH5ZrppOa6YbgWSdkkalzR+5syZHmP0bkfft9iO0l7Hgk/KrZrOat6/HTCzUTMbMbORFSv6f0bwg75vsR2lvY5eC/XqhUNZur/wm4GYlqPjei3Uw8Ct6fGtwEO15Z9KP+1tAs7VDo3FGMsdwNlY7gA1TS4b3A/8CnifpJOSbgPuArZIOkF1bnhXevo+4EVgEvgO8NlWUi/QntwBnO3JHaBmzrevmNnOGb710Wmea8DtCw3VttneAz6ISno9nbtS/p/cAVrS7zcBzqRzhRqGDwJM52DuAEnnCvWT3AFaMpY7QNK5Qo3lDtCSUj4t07lCvZI7QEtKeV2dK9RfcgdoSRQqk3flDtCSUl5XFGpIlPK6OleoqW/sGhalvK4o1JDYPvdT+qJzhdqUO0BL3p87QNK5QoV2dbJQN+QO4Kyk19PJQt2RO4CzPbkD1HSyUKWcwHrZnDtATScLFdrT2UJ9PHcAJ6W9js4W6oHcAZyU9jo6WyiAn+UOsECHcweYRqcLtYXBHdtgKTCSO8Q0Ol0ogL/mDtCjUnN3vlAAH8gdYJ6uyR1gFlEo4De5A8zTeO4As4hCJYMydHPpOaNQNaUPwnA2d4AGolA1lwOv5g4xg9PAO3KHaCBmUpjinVSHlUso41PGiyjnU8FNxB5qBufJ/7aQmxisMkHsoWY1lu7fRn+v+7wVONfH7XmKPVQD54Cn+rStpxjcMkEUqrGrqc6tNre0/s1p/Ve3tP5+iULN0wGqf3gDfkzvc9qtAR6sravkweznI86hFmA7b7z782XgCarBvw5RXTM6RTWJ43LgWuD6dBvEiRWbmrNQklYD91ENHW3AqJndLWkZ1SC0a4HfAbeY2Z8lCbgb2Ab8Hfi0mfXrFCSb9wCfSLcua3LIOw980cw2UH2s7XZJGxiS2RSCryYzKZy6sIcxs9eA56gGsx+K2RSCr3mdlEtaS/WDyCEWOJtC7pkUQjsaF0rSW4AfAXeY2f9d5+tlNoXcMymEdjQqlKRLqcr0fTN7MC2O2RTCRZoMfC/gu8BzZvb12rcGejaF0I4m16E+DHwSOCbp6bTsS1SzJ/wwzazwEnBL+t4+qksGk1SXDT7jmjgUrclMCgcBzfDtgZ1NIbQjfvUSXEWhgqsoVHAVhQquolDBVRQquIpCBVdRqOAqChVcRaGCqyhUcBWFCq6iUMFVFCq4ikIFV1Go4CoKFVxFoYIrVe/YzRxCeg2YyJ2joeUMxnCXbedcY2YXff6tlMEyJsysxIkBLiJpfBCy5soZh7zgKgoVXJVSqNHcAeZhULJmyVnESXkYHqXsocKQiEIFV9kLJWmrpAlJk5J2z/0nWs2yV9JpScdry5ZJekzSiXR/WVouSfek3Eclbexz1tWSDkh6VtIzkj5fRF4zy3ajmnniBeC9wGLgt8CGjHmuBzYCx2vLvgbsTo93A19Nj7cBP6Ua92ETcKjPWVcBG9PjpcDzwIbceXMX6kPAo7Wv7wTuzJxp7ZRCTQCrav+IE+nxt4Gd0z0vU+6HqGa9zZo39yGv0fCJmS1o6Md+8ByqcqFyF2qgWPVfu6jrLN5DVS5U7kINwvCJxQ79WOJQlbkLdRhYJ+lKSYuBHVRDKpakyKEfix2qMucJcDo53Eb1E8oLwJczZ7mfakaNf1OdY9xGNZHmfuAE8HNgWXqugG+m3MeAkT5nvY7qcHYUeDrdtuXOG796Ca5yH/LCkIlCBVdRqOAqChVcRaGCqyhUcBWFCq7+C59AOAgnqtfEAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+       "<Figure size 144x144 with 1 Axes>"
       ]
      },
      "metadata": {
@@ -137,13 +137,12 @@
    ],
    "source": [
     "buffer = np.zeros((256, 256, 4), dtype=np.uint8)\n",
-    "surface = skia.Surface(buffer)\n",
+    "surface = skia.Surface(buffer, colorType=skia.kRGBA_8888_ColorType)\n",
     "canvas = surface.getCanvas()\n",
-    "paint = skia.Paint()\n",
-    "paint.setAntiAlias(True)\n",
-    "paint.setColor(skia.ColorCYAN)\n",
+    "paint = skia.Paint(AntiAlias=True, Color=skia.ColorCYAN)\n",
     "canvas.drawCircle((128, 128), 64, paint)\n",
     "\n",
+    "plt.figure(figsize=(2, 2))\n",
     "plt.imshow(buffer)\n",
     "plt.show()"
    ]
@@ -152,12 +151,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It is also easy to copy pixels from an image:"
+    "NumPy arrays can be also used as `Image` instead of `Surface`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAGJJREFUeJzt0IENgCAQBEG0/56xCIUNcaYA2L8xAAAAAACAv7g2/DEXv//qhvurilMZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOAAAAANjtATuzATANtKc0AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "array = np.zeros((64, 64, 4), dtype=np.uint8)\n",
+    "array[24:48, 24:48, 3] = 255\n",
+    "\n",
+    "image = skia.Image(array, alphaType=skia.kUnpremul_AlphaType)\n",
+    "display.Image(data=image.encodeToData())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to copy pixels from an image to numpy array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -177,9 +208,70 @@
     "with open('../skia/resources/images/color_wheel.png', 'rb') as f:\n",
     "    image = skia.Image.DecodeToRaster(f.read())\n",
     "    \n",
-    "buffer = np.zeros((image.height(), image.width(), image.imageInfo().bytesPerPixel()), dtype=np.uint8)\n",
-    "assert image.readPixels(buffer), 'Failed to read'\n",
+    "info = image.imageInfo()\n",
+    "buffer = np.zeros((info.height(), info.width(), info.bytesPerPixel()), dtype=np.uint8)\n",
+    "assert image.readPixels(info, buffer), 'Failed to read'\n",
     "\n",
+    "plt.imshow(buffer)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Canvas or surface can copy to numpy array, too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJQAAACPCAYAAAAcLfKMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAKlklEQVR4nO3dfWxV9R3H8ff3gqUPlAIWEB8oLlbDw4piC7OilCwjlTnxj8l0WXTEjCxR/1myhbgl8x+Xzf3j3MwWs/lAMkX5A2QZcTIj1AoD2gWkRUoReWgDtEwpUCig97s/7oVcaC99uL/T3+/2fl9Jc9vD7T2fUz4559xz7/39RFUxxpWY7wBmZLFCGaesUMYpK5RxygplnLJCGaciKZSI1IpIi4jsF5GVUazDhElcX4cSkVHAPuA7QBuwA3hMVfc4XZEJUhR7qHnAflU9oKoXgNXA0gjWYwI0OoLHvAk4kvJzGzD/Wr9QWlqq06dPjyCKiUpjY+MJVZ109fIoCjUgIrICWAEwbdo0GhoafEUxQyAih/paHsUhrx24JeXnm5PLrqCqr6hqpapWTprUq+gmS0VRqB1AuYjcKiJ5wKPA+gjWYwLk/JCnql+JyNPAv4BRwKuq2ux6PSZMkZxDqeoGYEMUj23CZlfKjVNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFPePjk8knR0dvKbPXs4MXo0nfn5nCgspLOkhBMTJlD65ZdM6uqi9OxZJvX0UPrVVzw7cyaTR+iHW61QQ9TR2cmaPXtYU1LCRxUVxBcu7PN+RwoKOHLjjVcs+2M8zn07d7Ls1Cm+P2PGiCqX8+F8hqKyslKzZWyDVfX1/K24mLo5c5w95v27dvGTM2f40b33OnvMqIlIo6pWXr3c9lCDsH7bNp5YsMD549bNmUMdMGHHDr5bVeX88YeTnZQPwLamJu5pamLp/GuOSpSxB6uqWPDJJ2zZvTvS9UTJ9lBpHDh8mGXd3TTOmAGzZw/bej+uqODSgW9eczN/HzuW28rKhm39mbJCpTFn4kTOTJvmNcP2WbOYe/o0p7ymGBw75F2lp6eHp+vqODN2rO8oAJwuLuaZzZs5d+6c7ygDYoVKceDwYSrb2nj5/vt9R7nCnxYuZH5bG/sP9TloXFCsUClWtrfTfNttvmP0aXd5Ob9q7zUQYHCsUMD7jY2MisdZc889vqNc09vV1YyKx3kv4Gt2VijgkfJy4rHs+FPEYzEeLS/3HSOt7PgrRuzUuHG+IwxKV0mJ7whpZVQoETkoIrtFZKeINCSXTRSRjSLSmryd4CZqNFZv2eI7wpCs27bNd4Q+udhDLVLVO1Ne11kJfKCq5cAHyZ+DFI/HefaWW/q/Y4CeGz+eeDzuO0YvURzylgJvJL9/A3g4gnU4sWrLFj7P0kLtuuMOVgW4d820UAq8LyKNyZkRAKao6tHk98eAKX39ooisEJEGEWno7OzMMMbgvbh5M8sjeKF3OC1fsIAXN2/2HeMKmRZqgarOBR4AnhKRK64IauK9MX2+P8b3TAqrr79+2NcZhdC2I6NCqWp78rYDWEtiJqrjIjIVIHnbkWlI1451dLB91izfMZzYPmsWR48f9x3jsiEXSkSKRKT40vfAYqCJxDQcTyTv9gTwbqYhXVu3dy8q4juGEyrCuy0tvmNclsm7DaYAayXxHzMaeFNV3xORHcA7IvIkcAhYlnlMt9YVFvqO4NS6wkJ+6jtE0pALpaoHgF7vg1XV/wHfziRUlE6fPs2HFRW+Yzj1YUUFFy9e5LrrrvMdJfeulD/f2MiFvDzfMZy6kJfH8x9/7DsGkIOFOpklr9kN1rFAtiuMFMPo2JgxviNEIpTtyr1CFRX5jhCJULYr9wo1frzvCJEIZbtyrlAni4t9R4hEKNuVc4W64YsvfEeIRCjblXuF6uryHSESoWxX7hXq7FnfESIRynblXqEuXvQdIRKhbFfuFSqA0WaiMN13gKScK9TPqqspCeR8w5Vxp07xVHW17xhADhYqLy+Pmr17fcdw6oGmpiBeGIYcLBRA7fnzviM4VRvQhxVyslDfKy9HRsi5lKhSe/vtvmNclpOFumnqVOY1N/uO4cS85mZumDzZd4zLcrJQALUnTviO4MTDgW1HzhbquZoaXquv9x0jI6/V17OypsZ3jCvkbKEAHq+u5putrb5jDMns1lYeD+RSQaqcLlQsFuOFLL0m9fuuLmKBvEszVXiJhlltZa+htrNCqLlzvlBA1l05H3cq3GFcrVDAm/v2EQvo4uC1xOJx1gR83meFApZUVfF1LMYPA/koUjqPbN3K17EYi+++23eUtKxQKf46dy5zP/3Ud4w+3dnSwqq77vIdo19WqBQFBQXUT5/O0sBGh3tw+3a2lpWRn5/vO0q/bCaFqxQUFLB23jxGqQYxoIaosr6qCgkgy0DYHqoPIsK67dsp9Py22oJz5/hHQ0PWlAmsUGk9NH8+3YWFnOnu5oVNm7ihY3iGuZrS2cnvNm3iTHc3ZwsKsm66MytUP4qKivh5TQ2fjxvHSxEPP/iXujoOFhfzi5oaigL5JPBg2TnUAOXn5/PMwoWM/egj3iosZKOjp+75PT0samrikXPnWB7YHDNDYYUapOX33cdyoLu7mw+amvjn+fNsKC+nberUAT/GzUePsqS1lSVjxrC4ooKCQF9GGQor1BAVFRXx0Pz5PJT8+Z2tWzl0/jyHYjEO5+dzaPx4Dk2ZQtnx40w7eZKynh7K4nGm5eXxg+pqGEQBs0m/hRKRV4EHgQ5VnZ1cNhF4m8Sndw4Cy1T1S0k8HfkDsAQ4C/xYVf8bTfSwLEs38VDA02hEYSAn5a8DtVctSzdbwgNAefJrBfBnNzFNtui3UKpaB1w9EkO62RKWAqs04T/A+EtDTJvcMNTLBulmS7gJOJJyv7bksl58z6RgopHxdahrzZbQz+95nUnBRGOohUo3W0I7kDobz83JZSZHDLVQ6WZLWA88LgnfArpSDo0mBwzkssFbQA1QKiJtwK+B39L3bAkbSFwy2E/issHyCDKbgPVbKFV9LM0/9ZotIXk+9VSmoUz2sheHjVNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUaACzMonIaaDFd44BKgXCmmClb1HnLFPVXp9/C2WwjBZVzYohSESkIRuy+spphzzjlBXKOBVKoV7xHWAQsiWrl5xBnJSbkSOUPZQZIbwXSkRqRaRFRPaLyMr+f2P4iMhBEdktIjtFpCG5bKKIbBSR1uTtBE/ZXhWRDhFpSlnWZ7bkWBMvJf/Gn4jI3KhyeS2UiIwCXiYx8t1M4DERmekzUx8WqeqdKU/B043eN9xeJ8CRBX3voeYB+1X1gKpeAFaTGAUvZOlG7xtWoY4s6LtQAx7xzhMF3heRRhFZkVyWbvS+EGQ8smCmQrlSHqoFqtouIpOBjSKyN/UfVVVFJMinyb6y+d5DBT3inaq2J287gLUkDtHpRu8LgfeRBX0XagdQLiK3ikge8CiJUfC8E5EiESm+9D2wGGgi/eh9IfA/sqCqev0iMeLdPuAz4Je+86Tk+gawK/nVfCkbcD2JZ1CtwL+BiZ7yvQUcBS6SOCd6Ml02QEg8m/4M2A1URpXLrpQbp3wf8swIY4UyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOPU/wFW6pFgOZFw6gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 144x144 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJQAAACPCAYAAAAcLfKMAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAKlklEQVR4nO3dfWxV9R3H8ff3gqUPlAIWEB8oLlbDw4piC7OilCwjlTnxj8l0WXTEjCxR/1myhbgl8x+Xzf3j3MwWs/lAMkX5A2QZcTIj1AoD2gWkRUoReWgDtEwpUCig97s/7oVcaC99uL/T3+/2fl9Jc9vD7T2fUz4559xz7/39RFUxxpWY7wBmZLFCGaesUMYpK5RxygplnLJCGaciKZSI1IpIi4jsF5GVUazDhElcX4cSkVHAPuA7QBuwA3hMVfc4XZEJUhR7qHnAflU9oKoXgNXA0gjWYwI0OoLHvAk4kvJzGzD/Wr9QWlqq06dPjyCKiUpjY+MJVZ109fIoCjUgIrICWAEwbdo0GhoafEUxQyAih/paHsUhrx24JeXnm5PLrqCqr6hqpapWTprUq+gmS0VRqB1AuYjcKiJ5wKPA+gjWYwLk/JCnql+JyNPAv4BRwKuq2ux6PSZMkZxDqeoGYEMUj23CZlfKjVNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFPePjk8knR0dvKbPXs4MXo0nfn5nCgspLOkhBMTJlD65ZdM6uqi9OxZJvX0UPrVVzw7cyaTR+iHW61QQ9TR2cmaPXtYU1LCRxUVxBcu7PN+RwoKOHLjjVcs+2M8zn07d7Ls1Cm+P2PGiCqX8+F8hqKyslKzZWyDVfX1/K24mLo5c5w95v27dvGTM2f40b33OnvMqIlIo6pWXr3c9lCDsH7bNp5YsMD549bNmUMdMGHHDr5bVeX88YeTnZQPwLamJu5pamLp/GuOSpSxB6uqWPDJJ2zZvTvS9UTJ9lBpHDh8mGXd3TTOmAGzZw/bej+uqODSgW9eczN/HzuW28rKhm39mbJCpTFn4kTOTJvmNcP2WbOYe/o0p7ymGBw75F2lp6eHp+vqODN2rO8oAJwuLuaZzZs5d+6c7ygDYoVKceDwYSrb2nj5/vt9R7nCnxYuZH5bG/sP9TloXFCsUClWtrfTfNttvmP0aXd5Ob9q7zUQYHCsUMD7jY2MisdZc889vqNc09vV1YyKx3kv4Gt2VijgkfJy4rHs+FPEYzEeLS/3HSOt7PgrRuzUuHG+IwxKV0mJ7whpZVQoETkoIrtFZKeINCSXTRSRjSLSmryd4CZqNFZv2eI7wpCs27bNd4Q+udhDLVLVO1Ne11kJfKCq5cAHyZ+DFI/HefaWW/q/Y4CeGz+eeDzuO0YvURzylgJvJL9/A3g4gnU4sWrLFj7P0kLtuuMOVgW4d820UAq8LyKNyZkRAKao6tHk98eAKX39ooisEJEGEWno7OzMMMbgvbh5M8sjeKF3OC1fsIAXN2/2HeMKmRZqgarOBR4AnhKRK64IauK9MX2+P8b3TAqrr79+2NcZhdC2I6NCqWp78rYDWEtiJqrjIjIVIHnbkWlI1451dLB91izfMZzYPmsWR48f9x3jsiEXSkSKRKT40vfAYqCJxDQcTyTv9gTwbqYhXVu3dy8q4juGEyrCuy0tvmNclsm7DaYAayXxHzMaeFNV3xORHcA7IvIkcAhYlnlMt9YVFvqO4NS6wkJ+6jtE0pALpaoHgF7vg1XV/wHfziRUlE6fPs2HFRW+Yzj1YUUFFy9e5LrrrvMdJfeulD/f2MiFvDzfMZy6kJfH8x9/7DsGkIOFOpklr9kN1rFAtiuMFMPo2JgxviNEIpTtyr1CFRX5jhCJULYr9wo1frzvCJEIZbtyrlAni4t9R4hEKNuVc4W64YsvfEeIRCjblXuF6uryHSESoWxX7hXq7FnfESIRynblXqEuXvQdIRKhbFfuFSqA0WaiMN13gKScK9TPqqspCeR8w5Vxp07xVHW17xhADhYqLy+Pmr17fcdw6oGmpiBeGIYcLBRA7fnzviM4VRvQhxVyslDfKy9HRsi5lKhSe/vtvmNclpOFumnqVOY1N/uO4cS85mZumDzZd4zLcrJQALUnTviO4MTDgW1HzhbquZoaXquv9x0jI6/V17OypsZ3jCvkbKEAHq+u5putrb5jDMns1lYeD+RSQaqcLlQsFuOFLL0m9fuuLmKBvEszVXiJhlltZa+htrNCqLlzvlBA1l05H3cq3GFcrVDAm/v2EQvo4uC1xOJx1gR83meFApZUVfF1LMYPA/koUjqPbN3K17EYi+++23eUtKxQKf46dy5zP/3Ud4w+3dnSwqq77vIdo19WqBQFBQXUT5/O0sBGh3tw+3a2lpWRn5/vO0q/bCaFqxQUFLB23jxGqQYxoIaosr6qCgkgy0DYHqoPIsK67dsp9Py22oJz5/hHQ0PWlAmsUGk9NH8+3YWFnOnu5oVNm7ihY3iGuZrS2cnvNm3iTHc3ZwsKsm66MytUP4qKivh5TQ2fjxvHSxEPP/iXujoOFhfzi5oaigL5JPBg2TnUAOXn5/PMwoWM/egj3iosZKOjp+75PT0samrikXPnWB7YHDNDYYUapOX33cdyoLu7mw+amvjn+fNsKC+nberUAT/GzUePsqS1lSVjxrC4ooKCQF9GGQor1BAVFRXx0Pz5PJT8+Z2tWzl0/jyHYjEO5+dzaPx4Dk2ZQtnx40w7eZKynh7K4nGm5eXxg+pqGEQBs0m/hRKRV4EHgQ5VnZ1cNhF4m8Sndw4Cy1T1S0k8HfkDsAQ4C/xYVf8bTfSwLEs38VDA02hEYSAn5a8DtVctSzdbwgNAefJrBfBnNzFNtui3UKpaB1w9EkO62RKWAqs04T/A+EtDTJvcMNTLBulmS7gJOJJyv7bksl58z6RgopHxdahrzZbQz+95nUnBRGOohUo3W0I7kDobz83JZSZHDLVQ6WZLWA88LgnfArpSDo0mBwzkssFbQA1QKiJtwK+B39L3bAkbSFwy2E/issHyCDKbgPVbKFV9LM0/9ZotIXk+9VSmoUz2sheHjVNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOOUaACzMonIaaDFd44BKgXCmmClb1HnLFPVXp9/C2WwjBZVzYohSESkIRuy+spphzzjlBXKOBVKoV7xHWAQsiWrl5xBnJSbkSOUPZQZIbwXSkRqRaRFRPaLyMr+f2P4iMhBEdktIjtFpCG5bKKIbBSR1uTtBE/ZXhWRDhFpSlnWZ7bkWBMvJf/Gn4jI3KhyeS2UiIwCXiYx8t1M4DERmekzUx8WqeqdKU/B043eN9xeJ8CRBX3voeYB+1X1gKpeAFaTGAUvZOlG7xtWoY4s6LtQAx7xzhMF3heRRhFZkVyWbvS+EGQ8smCmQrlSHqoFqtouIpOBjSKyN/UfVVVFJMinyb6y+d5DBT3inaq2J287gLUkDtHpRu8LgfeRBX0XagdQLiK3ikge8CiJUfC8E5EiESm+9D2wGGgi/eh9IfA/sqCqev0iMeLdPuAz4Je+86Tk+gawK/nVfCkbcD2JZ1CtwL+BiZ7yvQUcBS6SOCd6Ml02QEg8m/4M2A1URpXLrpQbp3wf8swIY4UyTlmhjFNWKOOUFco4ZYUyTlmhjFNWKOPU/wFW6pFgOZFw6gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 144x144 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "surface = skia.Surface(128, 128)\n",
+    "canvas = surface.getCanvas()\n",
+    "paint = skia.Paint(AntiAlias=True, Color=skia.ColorCYAN)\n",
+    "canvas.drawCircle((64, 64), 32, paint)\n",
+    "\n",
+    "info = canvas.imageInfo()\n",
+    "buffer = np.zeros((info.height(), info.width(), info.bytesPerPixel()), dtype=np.uint8)\n",
+    "assert canvas.readPixels(info, buffer), 'Failed to read'\n",
+    "\n",
+    "plt.figure(figsize=(2, 2))\n",
+    "plt.imshow(buffer)\n",
+    "plt.show()\n",
+    "\n",
+    "info = surface.imageInfo()\n",
+    "buffer = np.zeros((info.height(), info.width(), info.bytesPerPixel()), dtype=np.uint8)\n",
+    "assert surface.readPixels(info, buffer), 'Failed to read'\n",
+    "\n",
+    "plt.figure(figsize=(2, 2))\n",
     "plt.imshow(buffer)\n",
     "plt.show()"
    ]
@@ -195,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +302,7 @@
     "        pil_image.width,\n",
     "        pil_image.height,\n",
     "        COLORTYPES.get(pil_image.mode),\n",
-    "        skia.AlphaType.kPremul_AlphaType)\n",
+    "        skia.AlphaType.kUnpremul_AlphaType)\n",
     "    pixels = pil_image.tobytes()\n",
     "    assert len(pixels) == info.computeMinByteSize(), 'Pixels do not match the expected size'\n",
     "    pixmap = skia.Pixmap(info, pixels, info.minRowBytes())\n",
@@ -230,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,17 +342,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAlTUlEQVR4nO2deZhUxbn/P3XO6Z5hGBgUQcAdUeMOaq5XjRAxGhO84p7rBYMi+vNJco0Srks00RtNJBqfuGZxQ1DUuCVu0avmUSEmcQu4RJO4gbgHhGGZpc+pen9/1Knu08vM9DaLJN95ztPd1Wep6fett96t3lJsjFjz1BoaGxsJVAA+eL4HAYgvEIDyFaQAHwiAFIgnkAKVUognaAWdImil2BCGrO/sZKeWln7+z+oO1d8dqBmt97XS5DehfIXnWUI7ouKTJa5KK/AtE6iUsgwRCCqw79257n2EJX4EaCCMmSEUISNCBvh0/XoOGDasf/7x+uCzxwBvXvsm2wzdBk95+cQLCo6YASSICe6I7xghSDCCn38OAVniRyKWCZRCAxEQYpnCMUaoFJ3G8MayZZw4blx//CzVwuvvDpSF+afPJ/PzDPoXmu3S2+FrH4UCwR4Oyh6CZN8rpWybJyhfIUry3ytBeYn2QGEALYIBROU+R64NMCJoEUQpFBB4HjuMHctiY3gsDDlj/vy+/pmqwcCWAJnLM/jKR3mq5OjOG+kpO4rdaJZA8s93RwB4oNKJcxKiX3wr5t0Ij5TKSQHImxZcewSYhIRwr50idBrD0alU3/xglWNgMkDmBxl8fPApPXc7IhcSPSX5BHcKXmBFv5sCnPhP3tOK/VisQx4xTdzmXqWQKeJzo/g7d252yhChwxhOGHiMMHAYYN6x85i+w/TiuT0xOknFxG9IENMXaCAnERoswUlbjZ40SEoCUjTRyBAJpJEUI8SXQSql0uLRamBlBO1aqbURtEcQGXLzvmMCXXBkGYIcg0Txq3E6RKI9EqHdGJ5YuJDbTzqpb37Y7jEwGCA6K8JTniVioeJWYvTmifR07lUapIUmviibyEVqlBrvN/n16N7SNq0v+ljkyXVKrY2UwohglEKIGSHWE7LEjqeQJBPlSYtYInyj/yVC/zJAxzc6SEnKjnivQDN371M57T0r4huxBE/LKBkq5zKWbwfbBH3Z9avfjaJL31Xqo86Y+BIzhSEnAbLTgGOIuC07nYiwNgw5r7GxL/ueRP8wwPxD5jNty2nWQVPKNk8Q3o1wSceivoHdZaTc7x/gb6cGDwgJ9s4Gkal/0vqVtV7OqtLE1gI5BdER3UkLiaeJjAhP33YbD82Y0dd97/sfMDPNavZ4WCXPKWEFSltWrKcE1aiGmxZzn/qSmuiPqotY7y0s+ljro54U+TTyvKyV6hhBEjqFTloa8esGrbkkne7L/vYdA8w/cD7TNp9mTTqPYo0+JrpKW8XNpAxqkDpIb6/vDb4SbKIaBsRoLxerO0WOeETr33+iFCb2FSQlgtMVstIAywQZEf5w66387uST+6KfffOjrjliDUMZmlXykqI+T+SnxI74QWqa3lPfljqi35WkeuDEh6Potr8r66qWpDMpViijxGfnXVy1fj3X937sofcZIDwszNr0BLFHrkHlzLrYZKMBJC1fNruZR1PTe43wHcCVwJPAX4G1wHrshNQEjAR2AY4HTqjzs79yp9aPvg14sQUBMdFFii0KEdq15trenRJ6lwGiL0ZZRS8v8uY8cDHhSTNaj9QfpC7o1RH/PeBG4KMyzlXArsBcYEqd+zFmbhR92OF5dlpIMEAhE7gp4Wd+r+k9vccA0ResbZ8NwTpxH8TzvSU8NLFEzpbx/la99k+uBw4Hnq7i2kZgNvDDuvYIlq7QesK1sW7g4DyMJBhAi9Apwk1Br5i59Q8GzfvcPPTnNSpUiBbQoERlNSBBrDTw2NvsYMS7xutN4ncA+1Md8d31P46PemL8Vr4vP/a8vYcbQwfQiY0dGKXIFLiZlVKcpDV71D/AVF8JMH+H+UwfND3rxUvG3LNzfRqkUR6S/5Epwfhed94cCdxfon1c/N1XgT2A14GHgXuAN0uc3wK8BGzTC318eGkUHf4Lz8PDElvIdyzphLWwZMECXqufhVA/Bmjdo5Uh0ZCc395PKHxu3h/EYNNi1gfz+8Rr9wvgGxQHjE8AFnZz3VeAR0u0TwdurVvvitF8mtYbtFKWCZxe4FzPxPEFEd5/5x2eqU/eQX2mgHlbzaO5rTk/UiJxLD73qAPN7n1GfIDrySc+wGF0T3yAR7BSoRBP1KNT3WD99b5/4JbG0CFCiHUZRyJEiXiCUYqRY8cy9pZb6vHM2hlg/pbz+br6OsrYeV602FcTvyKIku/oY/Si4OI+I/6jWJGdxGDgpjKvPxUYgrUEjgC+C9xWt951jUX/GwTfOUhr2oBMfISOCWJJoIHPnXgiW8+bV+vzap8C9GjtlDqr7bsQbQqn6d9gvmtmBYf1abDmdOCXBW2Tgd/1ZSdqwI2PRtGp1ypFKiFFTfw+GWR6vDYTsTYJEI2I8kW+qKwEwANR8rRcLX1NfCge/QB793UnasCsw4Lg6UuAdhE6yUmCZD6iBiZFUS3PqZ4B9DCNyigwlvDKxMQHl5e3hFuY6I/vl+DNihJtn+/zXtSGieN9f8lVQEechRzF0UOXsmYA8Tz2q54JqmOATHMGFSkUytr42potDqLkaa5nvL9Tv0Xu1pdo27HPe1E7xu/k+09fDrRjvYIhlhFC5ysQAc9jfBhWc//KGaC1uRU/4+flSYkR+97iBrlIJvp792vYtr1EW2/Y8H2BiXv7/g2zjaENctOBUnkJqp7vs92aNZXeuzIGmNc4j+YNzVbjTxA/lgWg+I4+Vc8KjunzOb8QukRbKab4rGDW0UHwneO1pjNemJLVBxLJJs1DhzKkMm9hZVZARISHl82zd1p/nJ51oPmiWRTc3u/EB2vCFU4DfwT+vR/6Uk9MnB5Fi192XkNiR0ciPzFjDG+UHzcomwFUSKg8PFEocQsvskmaaZpkM9ng/33AZOtsDnxS0LYAOLEf+lJvNO0WRe06jiaqOKBk4kUqWoS2KOL9hoZy7lXeFDA/mJ/28HzAE+dcSzh98BlIxAcYVaJtaV93opfQ9moQ0BZbBmEcLUx6C4MgIFXeVFAWAzRPj6Yns/PzL1I8ZG4zpa7rT+xWou3PFVx/B7AVMAv4e116VF88dEPCP+DWH2QSAaTh06aVc58eGaCpg460QrmUDgX4WaUP9jb7mCnBlwfEvJ/El0u0vUDxtNAVbgfew7qOdwcOxAaXBgqmHBoEe+8Yh5JDLCM4qyAE8DyaOzp6uk+POsAIjRaF0oIYIFKojCA2jS2NeJ1lSZGXeZmbuZnneI4VrOBTPqWTTjw8GmmkhRa2YRsmMIEZzGAf9inntt1iB4pDu1OB3/Rw3ZPYMHHhr7clpR1MXUGVqWGl0zBsGGy+OWyxBYwbB/vuC4ccYtu6fcYmxpCigJKxUhiJsLoGV/HIkHC0wWyu0cM1epjBDNHotEYrjV4SLYmkB7wkL8lkmSyeeEIFf/vJfrJIFvV0+25xsYhQcHgicno317woIluXuA4ROa3C50Ntx+jRIrfeKmJM189YsiSKGKw1w7RmU2OyR4vWDDOGQVV6CRtu4ZZtNHorgxmj0ZsbzGYGMzRmgNHhmLCnH+BSuVQapbEiwif/GqVRrpArKvzZ8zFRShNzdxG5SESeFZGVInK/iHxdRIZ2cf4oEVlX4bNrZQB3/PKX3T9n9BaZDIO0ptkYhmjNEGMYYgzNxtBkTIoqoobbhITbG8y2BrO1Ro82mBEaPUyj0xE9jvz/lv+umvDJP088uV6ur/Cnz+EDEdlOShO13KNBRG6q4tn1YgAQeeWVHp6looi01jRqTZMxDDKGBq1pMAbVtZu4y/m7MTb7fMCLlUAPQKEO5bBumecyLuNari3xMI/JTOYn/IQXeIHVrGYlK3mMxziDMxjBiKJrDIY5zOFjPu72mV1hNLAIGF/V1TAI+F9gZpXXFyJJVmPsEUXQ0QEffQS/+Q3stFPxdb/6Vff3/eqhxmRjBRmsReCUQrzKPL47hoS7GszOBrOjRo+NpcDmGj2sh9H/urwuQ2RI0UjeQraQJ+SJbrm4VVrlIDmopCSYKTMrHoFJhCLyDREZJuWNeiUiE0TkoRqeWWokl4Mnnii+7qCDer7OR2vLUlqjjEHF7zHGI5MpmwH21Og9DGY3g9lZo3cwmG01erRGzwqndzv3T5WpRcQbLaNlhawo658PJZTdZLeSDFQPfCAiZ4vI/mLn9WaximFaRDYRkV1E5FgRubcOz6qWAdavL75up516vm7asZlMQBQptFbkiK8wxjJHMYoMlT1DwpSPn6yHEAqSAdoF+dCXLs2K93iP7dmeDPnM9mt+zZEcWTYD3sd9nMIpjGMcO7Mze7EXk5nMHiUz9QYuSpmBUpikWAJr1sAmm+S3nXAC3H57z9cOUcZka1TESZk2ZCCSQus28lcaFTlwGjw8dxGCiEK5uMMBclC33b+Zm4uIP57xFREf4Oj4758VTz5Z3HZY92pXFl/8gtZP/97zdMx+GhEfFVfLKvYJ5CkHo+Yzv0Ghki7fpAfwRv/ebp0KT5dYfnEIh5TX839iaG2VwGXL4Oab4fTT87/ff3+YOrW8e936QBA0oJSteiSSRmW9uD5KDSc/RpAnpA4ICdM+vl2RhLh6SRkgbTY1LwSrunX5bsd2LGNZXttDPMSUuq+u+2ygXE9gd9h9d7j77tKWQZfXbBJFH69RyuB5gggoJYh4KOUTRZ8kpoE8CdAQm37ZpR2x+Qdwnfp1j//OKlYVtX2Oz5Xf838hD1Onwu9+VxnxAW68X6kGrAQIYmmQil+9gmkgywB7vcmbDTHBlSDJacAD9vUn9uhTbi+Rc7MFW3R7jarg758N998P3/wmvP56ZdftO9H3bTEdSCESIJL16QDb82Y2RJJlgBHbsm1y9DvCK0F2MLtXHe5dx7pqL/0XsOL/4IPhhRcqu26P3UVyRXeUSiHiI5JCKWGbbHpklgEaPbwAm/Dh6nA6L+CV/v1lRZSaaCpqe5/3K+v5Ro5CC98YCENYtw5WrICnnrImXxIffmgVw7Vry3/ONff7vqu+4AifjqcBlfAMZt+kBPGFrKhwzOABW6jtypK/o0rk4bzIi+X3+p8QSkEQQHMzbLklTJoE8+fDKafkn/fii/DAA+Xfd4vtlGpAxJbhUMpLTANBQj31AA5bw5pUPP8XmoDDZVQZrguLcRQvWP0jf+z2mq6iQP/MSKXs3F+I31W4rm3MKMsAqdgcTBbQ3YvWVogZoKWZ5mzB9UT2jwf8l5xXNjUO5uCitsd4rLJe/wsA7FhiFcvzz1d2jxnn2gonzieQLLdtaGqCmAEasOLeET9IWAPHBWeUne51EicxmMF5bStYwVVcVVnP/4WS8bsKwjkAHP/tIMgV0lUqaQ348TTgAaQVKh17AAPA6QKqQttrUzYt6fS5kAt5mZfLvs8LVKjyboR4993itl13rfw+DYikyfkEctOAZTEPEmI/VgTd/D9EhlY8GV/O5QxhSF5bK60czMHcX7JYSw7rWc9sZjORiZU+Ng8qLrKRPMrBM888w9ChQ4uunThxIh9/XF0+QjUQgVJJ3fvtV/m9NmnJldX2YwngBjpAMK2VVl8QFMqQW2wiwC49BH9KYWu25gf8gNnMzlPmVrKSoziKSUxiKlOZzGTGMpYP+IDneZ4HeZDHeIzVrK78v6wDXn31VaZNm8a6dfl+i1133ZVbbrmFzXvKzqwBIjYe0N4Oy5fbqN+llxafd0gVYZXdDhD5w29BoZSHUiZ2DQMczJo1alYHHc1p0kZs1q9bW5ABvidLZPsql3efyZlczdV10+h3Yif+yl/LOrfUiJdu4rDLli3jyCOP5KWX8qsKjB49mkceeYQ999yzss5m+1HVZSXxrW/BNddUft1bS7U+cwKEKGWrOOR6FZDJeM0pUtmNVRQqlbACqiU+wJVcyaVcWqQUVoommjid01naS+t6/vGPfzBz5swi4qfTae64446qiV9PHHAAnHdeddduP973U3FEsHBbLQ/f95zCl9QDrLeodpzDOTzP8xzO4aSprOLpFmzBN/kmb/AGP+fnNFL/kvrr1q3j9NNP58kSAfg777yTSZMm1f2ZleKEE+COO2DMmOrvERfny+oCOaeQUkGDimOFCmVieS1AUCfZvTM78yAP8i7vMo95LGYxb/M2K1lJO+0YDIMYxHCGszVbsyd7ciRH8iW+VI/Hd4nOzk5mz57NfffdV/Td9ddfz1FHHdWrz3cYMsR6AZubYehQu0BkzBgYP94uDtl//9qnkgARq98pZbCEt4kinhcEWHPPCOKeI0C6OFmoJmzN1lzIhXW9Z7XQWvP973+fG2+8sei7H/3oR8yaNasuzykn/asv0BiAjqxmFNmxrpwfIAiUfWfrEMbvBekNkTsQICJcccUVXHbZZUXfzZ49m7PPPrtss/GzgsENEEYiYZElIBIEYrc+dOv/wDkKWvq5272DefPmcc455xS1n3TSSVxyySX4vVeYu9/QPExk/Qbr+HE5gia2iwJXn935ABzvN8igASLA6ocHHniAUwrDbMARRxzBlVdeyaBBg/qhV72PQY02IGR9Ac7PE7uCs/7/RCzAB1rYrB+7XH8sXryY4447ruR3u+yyCy0b38bgWbSMsPkA1hWslB8HhnzAC2KzL1AoZwIGQNNGNgVMmzaNTBfRlLlz5/LMM8/0cY/6DoMG2UBQkMgK8mIm8AoJH2ClgaLC0NMAx4oV3a/s/973vkdbW1sf9aZvEahcUqgb+S4/wHMewEAQ5wlMKZRI+0anAzik02m22mqrvLYnn3ySG264oZ961LswbTbqZx1BBVNAdiefWBL4ggSCZNQ/Ni5bKIG77rqLyy+/vKj97LPP5vVKU3A/A+hcmdtv3c9bLCLiOYLnbbKuUMUFUjYO3HjjjUydOpVjjz2WEwqyLzOZDBdddBFRbfWXBxzMhtz0XhgT8JIKYEqhUth4AGrdRicB5s6dy8yZdqW/7/tceOGFpAt2Zbvrrru4++67+6N7vQZZZ80/v8AKSKOUF8SZQKmEMphWKI+NSyGaM2cOc+bMyfPy7bTTTlxxxRVF55533nl88MEHfdm93kWHWx9gLYF4Zwc8RLxsJhAxE2CtAJ+NSwxefPHFJb18p5xyCgcfnJ/Munz5cubOndttDsFnClFSB7Aj35qD4HkG46wAt5WjswQqf9IlkC1imzyKs4W7x+QS9/CAH1XepRiNXezQPmjQIC6++OKi9muuuYYnnqhhl6DC7iePv/Vw7V97uL5C+AkTMJ3NDbC+gTwrIJU9yXJM5bgAKJW4tojyd+u5CVhcon1/7M499cd+++3H+eefX9R+/vnn02rT5+uLJTV+XyHcMr8gS3y3XkApL4yIklphOn5tEORTvbRkWZHucRkwtKAtAorn2tL4SXx+EkOp/9aN+TjrrLPYfffd89qef/55rr22uNhVzfhTjd9XgE+Xap1b8GM9ge5zmjD0dAcdyXTwrFIIvCYXVTEJHkDpmtyvA2f3cO3/QMm8vxPj+/Yehg8fzg9/WLxB7AUXXMCf/1xJleEy0NM2ptVuc1oCL383R3CnBzhLwKOzUwEsMna7DwEkTg61tYdbZIq/psr46K7AawVtI7Alm7cscf57wARgZUH7LsBfKnpypUmhyXNOPfVUbropf7qaMmUK9957Lw3lVWCPO9HD958Cm3TRPrynjpbfjd+0aL12rVIhZDcXsQUj4Ft4ucUBycRQxy0Btcx/F2LXHCXxD+DbXZx/BsXEb8Du+d03UEpxwQUXMHLkyLz2hx9+mAULFtR28+aCz0u7OK+wvfC6CiFrVbbkj1sh7LyAEC8M8RKeQE8Qt0ooXVNVhuOxWy4W4rfAgwVtD2L36yzEfwD/WX0XqsC2227LpSWS8s8991zefvvt6m9c+FN0tfipsL3UT1gBFCIKJ/YdI1hFENzycINxEqDBeQWxCuHy6KoaHAI3USzuO4BCs+tiil3PWwA3V/VUKVH7sRLMnDmz6PpVq1YxduzYqvoDwCRgWOJzV9HnZPumUMsiqXevjiIVR/2c8ucygp1s9gA2tNGWZwkolN3zEz5gbvU9YAgwG8t3SbyAtRbAaveFbO/F1w1ho0ETcHji81MU72wVYWvVOxweX1clll+qsiV+7chPRAFZv574Ow5poSWpB3hxXCAN+OqjGmMCZ2HZPwkBfha//xnFWs0kLANsREiR7w9rpdgh9DfIq6gzmWodMgBEH9kYgHX75hghQGQ6w4ZBokKIiwP42GkgFU8DDQrVKe/U6BP9KcUq73LsHt2Fy2A3wfoCNjI0AF8oaCu0Lgs/f4FiPbpMdL5j534/tomSimCqsEIIAAbjY0vFuPxAV2PmLT21CodQEntg9+MuxCsl2mYCe9X2uIGIFDAOSKoRhQ6f5Oft46NKCfD3qVq70Z+0/+1nky36lWWAZctZ7hxB2QwhrB6AeqUOoeEfY+387rAnG+XohxwhC/UAuvjszquSATpf8TwXQXGM4BxCHSxb5s7LMsBXxjEumTSQTQ/D1sxfrxfVKAXAavtdpV67yvwbKRwhJyfa/kLO9fEJ+X6zg+LXypZUArB+ka0MniS6nzADv8a4bDGnvEIkkUY7l3AKGxZuiKeClXJ0HWKjU4DSqdlwNHZLp40Ubi4vjJW5wM/Sgvb949cqGODDo2zM38Zlc/H/AGgoKBufxwD33cEdSW9gOp4KGhUq7a3yjKyuAxN0tZ/hbbXfeiDDSYCRwL6J9hcKXsHub+s2T6lwCjCrRfSn1sWbCwPnwsHPFRSdz2OA2TOYQTJFPPG+UZCV0TEbV5ZIXyJJyK8k3v++4LXw+woZ4JMj7AhPVnrPWQBwLjNmJM8vWgJsNNrz8f24RE42QKRQ+E9ufAvn+gpJQia9e08BG8hXAJPfV8gAnb+3tr9bAhbElUGsQli8a0hRMbLN0qST28T6CadQoyDrwuld7kD1L3SD5Fz+b4nPbcBd5Pa2T8ffl7quB6w7LorI2v1KqUTs30fk30gVsVPJIgChRjf5BGJrBihMvEW0j5dRC9WAn68rWd7d2GirMoweDdtuC7vsYiszTJ4Mg2srb5OH5E8/GDgEeDj+nMyVOZR8928FEqDjnpzrF1xBSDv6k7Z/WdAZtOnEmE6Mbs+9jzJE7ZkvZyraPakIpeI1dUQ9NurbZhuRxx+voQ8Fx3sF319V4hxE5OqC81aUOKcE2g6LopUY8x5aL8OYNzHmbxjzGsa82sWGUVBiCnAwGkMEEiIqQpEBySAqg0qZ/6tsH7rPIpYvtxv1PP54fe5XKGsP7OK8wvYyJYB+FMC5f5N1gCDdzejvkpDz7+Q2NKgI5RiB0H5WnaiwfczGrwtoDSefbLfxqhWFc/ke2HBvEsOxW5UnUQYDRGPC7Nzvk1MCXeDnSRYu7OraLhlg1smcbEy+FHCSgAz4HR/6uqqk0X5CKUHvtu1sb4c334S5JULf778P99xT+/MLCelj812S+A+KI+c9MIBeqjUf5ty+bsFHLg/QmP/HSSd1dX23ojwYRiAaUTonBaQTIQN0glo94bO9fEwp8H2rCG6/PZxzDvz0p8XnPVIqW6lClCLk5B4+d3VdAmpCpyLeUMeLNX9nBXiIbF1C80+ix7k8AyE6nv81SpmEJGiDaNU+G5dz6Pjji9uefbb2+5YiQ2F4uFTiczdmYLTPmsjuyGyrfjm3b259R2eP03RZIzh6l0hplBKUGEQJSkCINQ4z8iETNE2pb125WlDtlp1ga7IXZv+2tNRHD6gjoofbIu/wTs8G0VJEqGyZX1sSFjYtsVFkIcrS5hc+ykKiWArESmF2Q8FOUB8c/tmeCpL46KPith126Pt+9ADv8FbPKgy25JNbkOeUvweZV5azpiwGmHEaM7SgiRcM5CmFnaDaUdEbzRvHVFCqTvsAKBmbhG5arh3xFaLA4CHZpV8pQj2DWTN6ug904QkshfSOpKNX46nAoBAQk0vmU9EGFb09MQrGLho4U0FPMMaK/PXr7ci/804osTqIowfOPsbRxGWR1+55ClS845KAQeEpHwGMpGgs24FcEbEWPsXCE/fjRATQoIgZIXYZq5WLVZiaE6a2+kkNqYy9hGqrf552WnU7NfQCwjnvhf7i0FcMSuztbSwvoBGM3Ma8Wyu5Z8W/yprnWDNUGIq2EkBJvNG4QZSHEg8xY28wwahZ/ScJ6lXq9WtfgxtusBWd+xnRjR9F3qmrPLsNlF2/rUiprLsHT9azan0LW1dU36+qXyr8E6GfwReDEDsZs4wQWwcy/mnxN+l5u9leQa0MsO++cOaZcOyxdlO/foZetFoz6R3syLfF33PEt0dEFKXZrOL8oap/qehpIi/CE23Ff540sE5p4d+X4LdUv+lE1aiWASZMgAUL7O5MA6RgtF7aqpnwWkx8uyW0okG5Ue8Sv3xGVvU7Vx3UCSYRGINxxqeKUBIikrGeQpVBsXgCelU9kknrAOf6bWuzbt+rrrIewCSWLIHvfAc++aR/+lgAvWiVZsJLKALlxqrd3kGLEAkYhEiqJb69X62dfAitxOYMuKVOonPWgShE9rpBgu36UCco1xH0wgtw6KGwumCjqv33t/u0Du9pnXbvIbpxWeSd+rZnR31uzhcCSezsjG/3/K4aNYd1FzzPAokQ54KSzthZFDuKVCfKe/ZUL1w6Z+BFD/fZx+7HUog//MFKgn4qEhXOWRp6p77ugUe8hQPK7uMpClHW9tfcxsKaM3PqMtHd8l1u+fp4vu6kQFIvSC77M6MONMFhfeAnqNQVfOml8N0S9YfuuQeOOaZ+/SoD0cTHI29xu6dozCp8gi+KdELjV7KAuxeczIUn1/q8umk6rXfR2hzSrDRKtLUOlEGJxO9tgqlIQ5P4Mzb0rmJYKQNkMpbQDz2U377VVrB0KWxaGLjvHURNt0eqPa0c8RVplSN+bl3v27z19jiOHtfT/cpB3TJ7Wo6n5dYl3CoRkoxK5E0HGZRqbVPmOmWitx4eOK7jdNoqhU0Fa7FXrIDeKBJVgOjhtyOt5mmv3fcUvnKiP97LS8Ub+iCEsoBfLagX8aGOEsBh/reZP31npsd9tv6BhNMo6z5WYEbvbYL/eqH+U0K10cDrrrM7NCbh+/DSS9Vt3FsGon1+FXkvrvVsJqhT9tKxmRdIcnH3An6z4GQur1nsJ9Frxm50HZEKbQg5qxtE8f5ECSsBD+TkJeKPqqO/oFoG6OyEgw+Gws0jpkyB+++njOhq2dBLP9Jqwp3KhnMbsIRvUEIgikAJKbGSIKUMmICDekV36lVvh74SrVyg2sTmYfwerHQQbT2HpmWMCea8X59/spZ8gOees57AQtxxB/xnfeoVhWOuDP0Pte9i+dkN3kmp/AXdPgZlAg7tNcW5191dmSvI+J34SsfrCxwTxMGkrKXgoos7H4Y/65HahlotDAB2n9bC/MAxY6xCOGJEyUvKQXjYTaH3fx941pOXG/XZsk3x6HdiX6N1iiN7NbDWJ/7O1rm0NndaC8GZiU4SKBMzgc52SBmDkc9Pl+CkW6vj/FoZYPVq+Pzn4a238tvPPLN0zmAPCI+7KfTvecMXGkTRqBzRLcFTSkjFhHepnB5rWb12GLOGVfywCtFnDu9505l34racqJK5S4WKos4xggszy84Hi/+Nu301eJOB4ZwvE7J6g0RTr4v8xe/7QoN4NHpCWpyIt/O9HxM+FSt8HoKShTyxcAY3l5XQUSv6/EfNnE/Gb8fP6gIxIyiTUBZjP0L2UGCahxt11n3K36WfIoxlQi96TcuR14i32nh2ZLsIngvfpkja9o7wEBCRiRo4rcqqQNWhX0bV/GOYP30rpqswHvnOlVyKERyjxHoCgNl6T+Nf8GtfjdpuQEgFeecj0UfO1erlj2JiN8SmnJvnHeFzoj753oBZyNMLZ3BHn4z6JPr1B+w4g45UOymnG7jDOZPc1JBtcwEnIcsUsulokRPOleD4M/o0cB9ddXfEj+9CfdimcsTOxeqtGRfE3rxUVrlz875lAiUhnWEjZ/fbRs0DYgSFMwm9EC+PEVxwKcpZDeiuJUQ2/jC4RWTPL4j61iXK37U+vgW99C9azr9W1DOvKVozCc3dxufdSM8RPKncpWLC+wkN38dgTMC5/Z5tMiAYAOCWL3HLtBFMyzKCS3B3EiBMuJidbuA+R1ip4L6LEt8701OlINWIDBoiNAxGbTpC0TgI05ExaFArWxXtEWr1BkVGIFRxHD6NHc3OQ5ez23Mh2lTsvAkSfvviQ/DEgLmNZ287mUfq6tGrFgOGAZIIjyb0OhMSIUHYrEQIc21OMkgYTxPuO3deQqoog1IF/7cIYmSwUTQrIZ0gpnPMuD1U4k1X4rh8kuh2hKdUvj3v4zx6GqPTXFZFyafexYBkAIfwq4ReBs8pi0lCSpjLQVAmxygS2VXMeUyROE91UwHdSJNBRpIjdu7VuWeLmcM5cbyCqJ1t02id5toBR3iHAb3OP/VbUv4T+Le2cqv20C4dPasgOg+izhE5qyQmRryzLrojPoCn2jxYj/XB+0rhKfuqlCWwihdiegVCROLonRFBS0RHtIBnF/hc5Q9k4sMAlwCl8Oa+vLltyLZeBi9bvMIFmqKc7uBMS6dPFIr9riCiRGSsKJpUfiJGsnJS8r1N0DAos5xPl4/j8bqFavsCnzkGKMSaXVjT3EEzYZxvoFGSQZLTApFNSCn3nsZsaWBTklp7jugeBs8IIm2EbS08VVEe/kDDZ54BSqF1JK0NIQ2pDlKiES8snuoKGUKyyWs+IiNFsZkyYARfNEZ3IB3DeGVYn/wDfYj/D7UtyEphRGlOAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "<PIL.Image.Image image mode=RGBA size=128x128 at 0x113B31DD0>"
+       "<PIL.Image.Image image mode=RGBA size=128x128 at 0x11D179550>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,13 +361,15 @@
     "def convert_image_to_pil(skia_image):\n",
     "    MODES = {\n",
     "        skia.kGray_8_ColorType: 'L',\n",
+    "        skia.kAlpha_8_ColorType: 'L',\n",
     "        skia.kRGB_888x_ColorType: 'RGB',\n",
     "        skia.kRGBA_8888_ColorType: 'RGBA',\n",
     "    }\n",
     "    mode = MODES[skia_image.colorType()]\n",
-    "    buffer = bytearray(skia_image.imageInfo().computeMinByteSize())\n",
-    "    assert skia_image.readPixels(buffer)\n",
-    "    return PIL.Image.frombytes(mode, (skia_image.width(), skia_image.height()), bytes(buffer))\n",
+    "    info = skia_image.imageInfo()\n",
+    "    buffer = bytearray(info.computeMinByteSize())\n",
+    "    assert skia_image.readPixels(info, buffer)\n",
+    "    return PIL.Image.frombytes(mode, (info.width(), info.height()), bytes(buffer))\n",
     "\n",
     "convert_image_to_pil(skia_image)"
    ]
@@ -289,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/skia/ImageFilter.cpp
+++ b/src/skia/ImageFilter.cpp
@@ -4,6 +4,8 @@
 #define CLONE(input) \
 (input) ? CloneFlattenable(*input) : sk_sp<SkImageFilter>(nullptr)
 
+namespace {
+
 py::object IsColorFilterNode(const SkImageFilter& filter) {
     SkColorFilter* colorfilter;
     if (filter.isColorFilterNode(&colorfilter))
@@ -11,12 +13,7 @@ py::object IsColorFilterNode(const SkImageFilter& filter) {
     return py::none();
 }
 
-sk_sp<SkImage> CloneImage(const SkImage& image) {
-    SkPixmap pixmap;
-    if (image.peekPixels(&pixmap))
-        return SkImage::MakeRasterCopy(pixmap);
-    return SkImage::MakeFromEncoded(image.encodeToData());
-}
+}  // namespace
 
 const int SkDropShadowImageFilter::kShadowModeCount;
 

--- a/src/skia/ImageInfo.cpp
+++ b/src/skia/ImageInfo.cpp
@@ -1,9 +1,5 @@
 #include "common.h"
 
-sk_sp<SkColorSpace> CloneColorSpace(const SkColorSpace* cs) {
-    return (cs) ? CloneFlattenable(*cs) : sk_sp<SkColorSpace>(nullptr);
-}
-
 void initImageInfo(py::module &m) {
 py::enum_<SkAlphaType>(m, "AlphaType")
     .value("kUnknown_AlphaType", SkAlphaType::kUnknown_SkAlphaType,
@@ -54,6 +50,7 @@ py::enum_<SkColorType>(m, "ColorType")
     .value("kA16_float_ColorType", SkColorType::kA16_float_SkColorType)
     .value("kR16G16_float_ColorType", SkColorType::kR16G16_float_SkColorType)
     .value("kA16_unorm_ColorType", SkColorType::kA16_unorm_SkColorType)
+    .value("kN32_ColorType", SkColorType::kN32_SkColorType)
     .export_values();
 
 py::enum_<SkYUVColorSpace>(m, "YUVColorSpace")
@@ -88,6 +85,12 @@ py::class_<SkColorInfo>(m, "ColorInfo",
     red, blue, and green; and :py:class:`ColorSpace`, the range and linearity of
     colors.
     )docstring")
+    .def("__repr__",
+        [] (const SkImageInfo& info) {
+            return py::str("ImageInfo({}, {}, {}, {})").format(
+                info.width(), info.height(), info.colorType(),
+                info.alphaType());
+        })
     .def(py::init<>(),
         R"docstring(
         Creates an :py:class:`ColorInfo` with

--- a/src/skia/Pixmap.cpp
+++ b/src/skia/Pixmap.cpp
@@ -56,6 +56,12 @@ py::class_<SkPixmap>(m, "Pixmap", R"docstring(
     Use :py:class:`PixelRef` to manage pixel memory; :py:class:`PixelRef` is
     safe across threads.
     )docstring")
+    .def("__repr__",
+        [] (const SkPixmap& pixmap) {
+            return py::str("Pixmap({}, {}, {}, {})").format(
+                pixmap.width(), pixmap.height(), pixmap.colorType(),
+                pixmap.alphaType());
+        })
     .def(py::init<>(),
         R"docstring(
         Creates an empty :py:class:`Pixmap` without pixels, with
@@ -428,16 +434,7 @@ py::class_<SkPixmap>(m, "Pixmap", R"docstring(
         :return: writable generic base pointer to pixels
         :rtype: memoryview
         )docstring")
-    .def("readPixels",
-        [] (const SkPixmap& pixmap, const SkImageInfo& info, py::buffer dst,
-            size_t dstRowBytes, int srcX, int srcY) {
-            auto buffer = dst.request();
-            size_t given = (buffer.ndim) ?
-                buffer.shape[0] * buffer.strides[0] : 0;
-            if (given < info.computeByteSize(dstRowBytes))
-                throw std::runtime_error("Buffer is smaller than required.");
-            return pixmap.readPixels(info, buffer.ptr, dstRowBytes, srcX, srcY);
-        },
+    .def("readPixels", &ReadPixels<SkPixmap>,
         R"docstring(
         Copies :py:class:`Rect` of pixels to dstPixels.
 
@@ -477,7 +474,7 @@ py::class_<SkPixmap>(m, "Pixmap", R"docstring(
             :py:meth:`height`
         :return: true if pixels are copied to dstPixels
         )docstring",
-        py::arg("dstInfo"), py::arg("dstPixels"), py::arg("dstRowBytes"),
+        py::arg("dstInfo"), py::arg("dstPixels"), py::arg("dstRowBytes") = 0,
         py::arg("srcX") = 0, py::arg("srcY") = 0)
     .def("readPixels",
         py::overload_cast<const SkPixmap&, int, int>(

--- a/src/skia/Shader.cpp
+++ b/src/skia/Shader.cpp
@@ -1,14 +1,6 @@
 #include "common.h"
 #include <pybind11/stl.h>
 
-template <>
-sk_sp<SkShader> CloneFlattenable(const SkShader& shader) {
-    auto data = shader.serialize();
-    auto flat = SkShader::Deserialize(
-        shader.getFlattenableType(), data->data(), data->size());
-    return sk_sp<SkShader>(reinterpret_cast<SkShader*>(flat.release()));
-}
-
 #define GET_SKSCALAR_PTR(pos) \
 ((pos.is_none()) ? nullptr : &(pos.cast<std::vector<SkScalar>>())[0])
 

--- a/src/skia/common.h
+++ b/src/skia/common.h
@@ -5,7 +5,10 @@
 #include <skia.h>
 #include <sstream>
 
+namespace pybind11 { class array; }  // namespace pybind11
+
 namespace py = pybind11;
+
 
 PYBIND11_DECLARE_HOLDER_TYPE(T, sk_sp<T>);
 
@@ -14,8 +17,26 @@ sk_sp<T> CloneFlattenable(const T& flattenable) {
     auto data = flattenable.serialize();
     return T::Deserialize(data->data(), data->size());
 }
+template <> sk_sp<SkShader> CloneFlattenable(const SkShader& shader);
 
 sk_sp<SkColorSpace> CloneColorSpace(const SkColorSpace* cs);
+
 sk_sp<SkImage> CloneImage(const SkImage& image);
+
+size_t ValidateBufferToImageInfo(
+    const SkImageInfo& imageInfo, const py::buffer_info& buffer,
+    size_t rowBytes);
+
+template <typename T>
+bool ReadPixels(T& readable, const SkImageInfo& imageInfo, py::buffer dstPixels,
+                size_t dstRowBytes, int srcX, int srcY) {
+    auto info = dstPixels.request(true);
+    auto rowBytes = ValidateBufferToImageInfo(imageInfo, info, dstRowBytes);
+    return readable.readPixels(imageInfo, info.ptr, rowBytes, srcX, srcY);
+}
+
+SkImageInfo NumPyToImageInfo(
+    py::array array, SkColorType ct, SkAlphaType at, const SkColorSpace* cs);
+
 
 #endif  // _COMMON_H_

--- a/src/skia/utils.cpp
+++ b/src/skia/utils.cpp
@@ -1,0 +1,70 @@
+#include "common.h"
+#include <pybind11/numpy.h>
+
+
+template <>
+sk_sp<SkShader> CloneFlattenable(const SkShader& shader) {
+    auto data = shader.serialize();
+    auto flat = SkShader::Deserialize(
+        shader.getFlattenableType(), data->data(), data->size());
+    return sk_sp<SkShader>(reinterpret_cast<SkShader*>(flat.release()));
+}
+
+sk_sp<SkColorSpace> CloneColorSpace(const SkColorSpace* cs) {
+    return (cs) ? CloneFlattenable(*cs) : sk_sp<SkColorSpace>(nullptr);
+}
+
+
+sk_sp<SkImage> CloneImage(const SkImage& image) {
+    SkPixmap pixmap;
+    if (image.peekPixels(&pixmap))
+        return SkImage::MakeRasterCopy(pixmap);
+    return SkImage::MakeFromEncoded(image.encodeToData());
+}
+
+size_t ValidateBufferToImageInfo(
+    const SkImageInfo& imageInfo,
+    const py::buffer_info& buffer,
+    size_t rowBytes) {
+    if (buffer.ndim == 0)
+        throw py::value_error("Buffer does not have dimensions.");
+    if (buffer.ndim == 1 && rowBytes == 0)
+        rowBytes = imageInfo.minRowBytes();
+    else if (buffer.ndim > 1)
+        rowBytes = buffer.strides[0];
+
+    if (rowBytes < imageInfo.minRowBytes())
+        throw py::value_error(py::str(
+            "Row bytes is smaller than required (expected {}, given {})"
+            ).format(imageInfo.minRowBytes(), rowBytes));
+
+    size_t byteSize = buffer.strides[0] * buffer.shape[0];
+    if (byteSize < imageInfo.computeByteSize(rowBytes))
+        throw py::value_error(py::str(
+            "Byte size is smaller than required (expected {}, given {})"
+            ).format(imageInfo.computeByteSize(rowBytes), byteSize));
+    return rowBytes;
+}
+
+SkImageInfo NumPyToImageInfo(py::array array, SkColorType ct, SkAlphaType at,
+                             const SkColorSpace* cs) {
+    if (!(array.flags() & py::array::c_style))
+        throw py::value_error("Array must be C-style contiguous.");
+    if (array.ndim() <= 1)
+        throw py::value_error("Number of dimensions must be 2 or more.");
+    if (array.shape(0) == 0 || array.shape(1) == 0)
+        throw py::value_error(py::str(
+            "Width and height must be greater than 0. "
+            "(width={}, height={})").format(array.shape(1), array.shape(0)));
+    // TODO: automatic colortype inference.
+    auto imageInfo = SkImageInfo::Make(
+        array.shape(1), array.shape(0), ct, at, CloneColorSpace(cs));
+    auto pixelSize = (array.ndim() == 2) ?
+        array.strides(1) : array.strides(2) * array.shape(2);
+    if (pixelSize != imageInfo.bytesPerPixel())
+        throw py::value_error(py::str(
+            "Incorrect number of color channels (expected {} bytes per pixel, "
+            "given {} bytes per pixel).").format(
+            imageInfo.bytesPerPixel(), pixelSize));
+    return imageInfo;
+}

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -14,6 +14,10 @@ def bitmap(info):
     return bitmap
 
 
+def test_Bitmap_repr(bitmap):
+    assert isinstance(repr(bitmap), str)
+
+
 def test_Bitmap_buffer(bitmap):
     import numpy as np
     assert isinstance(memoryview(bitmap), memoryview)

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -61,8 +61,10 @@ def test_Canvas_getSurface(canvas):
     assert isinstance(canvas.getSurface(), (skia.Surface, type(None)))
 
 
-# def test_Canvas_accessTopLayerPixels(canvas):
-#     canvas.accessTopLayerPixels()
+def test_Canvas_accessTopLayerPixels(canvas):
+    point = skia.IPoint(0, 0)
+    assert isinstance(
+        canvas.accessTopLayerPixels(point), (type(None), memoryview))
 
 
 def test_Canvas_peekPixels(canvas):
@@ -71,8 +73,15 @@ def test_Canvas_peekPixels(canvas):
 
 @pytest.mark.parametrize('args', [
     (skia.Pixmap(), 0, 0),
-    (np.zeros((240, 320, 4), dtype=np.uint8), 0, 0),
-    (np.zeros((240, 320, 4), dtype=np.uint8),),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        bytearray(240 * 320 * 4),
+        320 * 4,
+    ),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        np.zeros((240, 320, 4), dtype=np.uint8),
+    ),
     (skia.Bitmap(), 0, 0),
 ])
 def test_Canvas_readPixels(canvas, args):
@@ -80,8 +89,15 @@ def test_Canvas_readPixels(canvas, args):
 
 
 @pytest.mark.parametrize('args', [
-    (np.zeros((240, 320, 4), dtype=np.uint8), 0, 0),
-    (np.zeros((240, 320, 4), dtype=np.uint8),),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        bytearray(240 * 320 * 4),
+        320 * 4,
+    ),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        np.zeros((240, 320, 4), dtype=np.uint8),
+    ),
     (skia.Bitmap(), 0, 0),
 ])
 def test_Canvas_writePixels(canvas, args):

--- a/tests/test_imageinfo.py
+++ b/tests/test_imageinfo.py
@@ -94,6 +94,10 @@ def test_ImageInfo_init():
     check_imageinfo(skia.ImageInfo())
 
 
+def test_ImageInfo_repr(imageinfo):
+    assert isinstance(repr(imageinfo), str)
+
+
 def test_ImageInfo_width(imageinfo):
     assert imageinfo.width() == 320
 

--- a/tests/test_pixmap.py
+++ b/tests/test_pixmap.py
@@ -10,6 +10,10 @@ def test_Pixmap_init(args):
     assert isinstance(skia.Pixmap(*args), skia.Pixmap)
 
 
+def test_Pixmap_repr(pixmap):
+    assert isinstance(repr(pixmap), str)
+
+
 @pytest.mark.parametrize('args', [
     tuple(),
     (skia.ImageInfo.MakeN32Premul(100, 100), None, 400),

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -9,10 +9,15 @@ def check_surface(x):
 
 
 @pytest.mark.parametrize('args', [
+    (240, 320),
     (np.zeros((240, 320, 4), dtype=np.uint8),),
 ])
 def test_Surface_init(args):
     check_surface(skia.Surface(*args))
+
+
+def test_Surface_repr(surface):
+    assert isinstance(repr(surface), str)
 
 
 def test_Surface_width(surface):
@@ -85,8 +90,15 @@ def test_Surface_peekPixels(surface):
 
 @pytest.mark.parametrize('args', [
     (skia.Pixmap(), 0, 0),
-    (np.zeros((240, 320, 4), dtype=np.uint8), 0, 0),
-    (np.zeros((240, 320, 4), dtype=np.uint8),),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        bytearray(240 * 320 * 4),
+        320 * 4,
+    ),
+    (
+        skia.ImageInfo.MakeN32Premul(320, 240),
+        np.zeros((240, 320, 4), dtype=np.uint8),
+    ),
     (skia.Bitmap(), 0, 0),
 ])
 def test_Surface_readPixels(surface, args):


### PR DESCRIPTION
* Add `ValidateBufferToImageInfo` and `NumPyToImageInfo` utilities
* Force `(imageInfo, ptr, rowBytes)` method signatures where applicable
* Add missing `Canvas.accessTopLayerPixels`