### PR TITLE
Add array interface support and PIL fromarray tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         python setup.py install
     - name: Test
       run: |
-        python -m pip install pytest glfw
+        python -m pip install pytest glfw pillow
         xvfb-run -s "-screen 0 640x480x24" python -m pytest tests
   build-macos:
     runs-on: macos-latest
@@ -116,7 +116,7 @@ jobs:
         python setup.py install
     - name: Test
       run: |
-        python -m pip install pytest pyopengl pyopengl-accelerate
+        python -m pip install pytest pyopengl pyopengl-accelerate pillow
         python -m pytest tests
     - name: Build docs
       run: |
@@ -185,5 +185,5 @@ jobs:
         python setup.py install
     - name: Test
       run: |
-        python -m pip install pytest glfw
+        python -m pip install pytest glfw pillow
         python -m pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,4 +7,4 @@ envlist = py35,py36,py37,py38
 [testenv]
 changedir = tests
 commands = py.test {posargs}
-deps = pytest numpy pyopengl pyopengl-accelerate
+deps = pytest numpy glfw pillow

--- a/src/skia/Bitmap.cpp
+++ b/src/skia/Bitmap.cpp
@@ -117,6 +117,14 @@ bitmap
                 throw std::out_of_range("Index out of range.");
             return bitmap.getColor(x, y);
         })
+    .def_property_readonly("__array_interface__",
+        [] (const SkBitmap& bitmap) {
+            return ImageInfoToArrayInterface(bitmap.info(), bitmap.rowBytes());
+        })
+    .def("tobytes",
+        [] (const SkBitmap& bitmap) -> py::object {
+            return py::module::import("builtins").attr("bytes")(bitmap);
+        })
     .def(py::init<>(
         [] (const SkBitmap* src) {
             return (src) ? SkBitmap(*src) : SkBitmap();

--- a/src/skia/Pixmap.cpp
+++ b/src/skia/Pixmap.cpp
@@ -93,6 +93,14 @@ py::class_<SkPixmap>(m, "Pixmap",
                 throw std::out_of_range("Index out of range.");
             return pixmap.getColor(x, y);
         })
+    .def_property_readonly("__array_interface__",
+        [] (const SkPixmap& pixmap) {
+            return ImageInfoToArrayInterface(pixmap.info(), pixmap.rowBytes());
+        })
+    .def("tobytes",
+        [] (const SkPixmap& pixmap) -> py::object {
+            return py::module::import("builtins").attr("bytes")(pixmap);
+        })
     .def(py::init<>(),
         R"docstring(
         Creates an empty :py:class:`Pixmap` without pixels, with

--- a/src/skia/common.h
+++ b/src/skia/common.h
@@ -41,5 +41,6 @@ SkImageInfo NumPyToImageInfo(
 py::buffer_info ImageInfoToBufferInfo(
     const SkImageInfo& imageInfo, void* data, ssize_t rowBytes = 0,
     bool readonly = true);
-
+py::dict ImageInfoToArrayInterface(
+    const SkImageInfo& imageInfo, size_t rowBytes = 0);
 #endif  // _COMMON_H_

--- a/src/skia/utils.cpp
+++ b/src/skia/utils.cpp
@@ -152,3 +152,126 @@ py::buffer_info ImageInfoToBufferInfo(
             throw std::runtime_error("Unsupported color type");
     }
 }
+
+
+py::dict ImageInfoToArrayInterface(
+    const SkImageInfo& imageInfo, size_t rowBytes) {
+    using namespace pybind11::literals;
+    auto byteorder = py::module::import("sys")
+        .attr("byteorder").cast<std::string>();
+    std::string bytemark((byteorder == "little") ? "<" : ">");
+    int width = imageInfo.width();
+    int height = imageInfo.height();
+    int bytesPerPixel = imageInfo.bytesPerPixel();
+    if (!rowBytes)
+        rowBytes = imageInfo.minRowBytes();
+    switch (imageInfo.colorType()) {
+        case kAlpha_8_SkColorType:
+        case kGray_8_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width),
+                "typestr"_a = py::str("|u1"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel),
+                "version"_a = 3
+            );
+
+        case kRGB_565_SkColorType:
+        case kARGB_4444_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width),
+                "typestr"_a = py::str("{}u2").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel),
+                "version"_a = 3
+            );
+
+        case kRGBA_8888_SkColorType:
+        case kRGB_888x_SkColorType:
+        case kBGRA_8888_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 4),
+                "typestr"_a = py::str("|u1"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 1),
+                "version"_a = 3
+            );
+
+        case kRGBA_1010102_SkColorType:
+        case kBGRA_1010102_SkColorType:
+        case kRGB_101010x_SkColorType:
+        case kBGR_101010x_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width),
+                "typestr"_a = py::str("{}u4").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel),
+                "version"_a = 3
+            );
+
+        case kRGBA_F16Norm_SkColorType:
+        case kRGBA_F16_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 4),
+                "typestr"_a = py::str("{}f2").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 2),
+                "version"_a = 3
+            );
+
+        case kRGBA_F32_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 4),
+                "typestr"_a = py::str("{}f4").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 4),
+                "version"_a = 3
+            );
+
+        case kR8G8_unorm_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 2),
+                "typestr"_a = py::str("|u1"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 1),
+                "version"_a = 3
+            );
+
+        case kA16_float_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width),
+                "typestr"_a = py::str("{}f2").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel),
+                "version"_a = 3
+            );
+
+        case kR16G16_float_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 2),
+                "typestr"_a = py::str("{}f2").format(bytemark),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 2),
+                "version"_a = 3
+            );
+
+        case kA16_unorm_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width),
+                "typestr"_a = py::str("<u2"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel),
+                "version"_a = 3
+            );
+
+        case kR16G16_unorm_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 2),
+                "typestr"_a = py::str("<u2"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 2),
+                "version"_a = 3
+            );
+
+        case kR16G16B16A16_unorm_SkColorType:
+            return py::dict(
+                "shape"_a = py::make_tuple(height, width, 4),
+                "typestr"_a = py::str("<f2"),
+                "strides"_a = py::make_tuple(rowBytes, bytesPerPixel, 2),
+                "version"_a = 3
+            );
+
+        case kUnknown_SkColorType:
+        default:
+            throw std::runtime_error("Unsupported color type");
+    }
+}

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -70,6 +70,21 @@ def test_Bitmap_getitem(bitmap, index):
     assert isinstance(bitmap[index], int)
 
 
+@pytest.mark.parametrize('color_type, shape, dtype', [
+     (skia.kAlpha_8_ColorType, (32, 16,), np.uint8),
+     (skia.kRGBA_8888_ColorType, (32, 16, 4), np.uint8),
+     (skia.kGray_8_ColorType, (32, 16,), np.uint8),
+     (skia.kA16_unorm_ColorType, (32, 16,), np.uint16),
+])
+def test_Bitmap_array_interface(color_type, shape, dtype):
+    from PIL import Image
+    bitmap = skia.Bitmap()
+    bitmap.allocPixels(
+        skia.ImageInfo.Make(16, 32, color_type, skia.kUnpremul_AlphaType))
+    assert not bitmap.isNull()
+    assert isinstance(Image.fromarray(bitmap), Image.Image)
+
+
 @pytest.mark.parametrize('args', [
     tuple(),
     (skia.Bitmap(),),

--- a/tests/test_pixmap.py
+++ b/tests/test_pixmap.py
@@ -30,6 +30,11 @@ def test_Pixmap_getitem(pixmap, index):
     assert isinstance(pixmap[index], int)
 
 
+def test_Pixmap_array_interface(pixmap):
+    from PIL import Image
+    assert isinstance(Image.fromarray(pixmap), Image.Image)
+
+
 @pytest.mark.parametrize('args', [
     tuple(),
     (skia.ImageInfo.MakeN32Premul(100, 100), None, 400),


### PR DESCRIPTION
- Add `__array_interface__` and `tobytes` methods to `Bitmap` and `Pixmap`
- Add PIL `fromarray` tests

Close #75 