### PR TITLE
Improve PIL compatibility

### DIFF
--- a/notebooks/Python-Image-IO.ipynb
+++ b/notebooks/Python-Image-IO.ipynb
@@ -80,23 +80,24 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABHNCSVQICAgIfAhkiAAAFf5JREFUeJztXdtyHDlyPehukuKI1Gokbyh2Yx7mT+yf8Ff6J+w/8cOGdxUhrTXicEj2peCHyqw6OEigqklpNjbCiGixC0ABJ28nE9VNKmW8ugfeXAN/wPh6i/L920b/+D7jDX7DDr8A+AXAF/vJ11+kX9/fb4HhTbh8uT3367xX+waCFopyLOEOP+DQlL4FgWG8PgGbuzNh8PuvwAbNluxnbk9ZaPlFdzcWXGxJrr8dgkge3a0LIzfGqHUMolvzijW0/mgXw7oWLR7qevXEF0FZhNBTRgeOGGSN2rK8z1XPd2ktx58E7qnpxe4QtlDna5TRgbPT9Zbv2sicZP8u7rUGTznYm8gbpqjz+7cuhLUwZE6HslptCHu/DzkEG3Q3/O4oliFEE85onQh5nlDnkt6zWzcYXhYha+/+HnH4DMrSVif3pdZc+TmW+g7BsHbJ5rwXWKpjkH9A+32o//u3F2jzm1NWq/0uldg/YxNl7ID8Aspar9pzi4/uAt+8/Q6hudIjd0A6I0IUeAr6XthaYM8Kq6XJZ5zUOu2semJlP1NW7s4E6iln7Ntq1YqpN/gNNjzzprVHiWneuZhrysKA1uFicbW1CNoRu1o1/6CEnztbn5UXVypAkvrzpF7j1KtW7j3xOOvB4vMo6JuwJcNo9S08OvEIye1A6UP6ZlVTL/jOsujLHetFrfdcdmGuR8hQQ2ppY536ny3cc9w0fJDUnXhWe1HU+8Ql1VqfRUjKz1dhfN83qWOe/aQyBa9nt/yiu898DmMGyYOdRxxDZ6Xz4alKuo9OnvcJQGfS8x5EpODtWZKvTWedKouGEmqp18FaKpZ55QJL5MjP5oqXP/UVZbxogaqtS+qJ/LPn0y9L8BwEBa6onuAPB9acU6uBcw+IYZuQrTLzuREelL1mkJzP+7jrZYfEaixatheYGsRF69XP2n9+qdx1z2iZ3tLiiG6QU7ldRlvi9aUl360B0KX96LpFZ6sSUsu3u1YtdtL0plEertL6zGbTeI/qpK4Al044TShV2zb6u3lkDVPm6IIX6pUTy7mRV+nxR/XRa8/WC5R1whQha5Srvr6Z7lwTVwt42jetauc+f6vnq/kG6ut93r2KuqKxBmVJlaV39UvghBEsk53exas1BWtRf2vR1fXPkqvm6d/Icfzn6ucYLapqyUAL7IBkEbLWpNqfV0Umt8r6rbTl77Xa6h4xelZqWTwVVzqyVJxM42pB3U4tqgZKwA4YBiB52bui9auSnlBdIaMs6QZSxXejZC1FaTxXq0zuofWD+kOxQqDkJtagiLEIyaf5Dt22VRqur7KWdFp4jkrfCv+wLyLJyPztSrKX/yJoGQR/E0zuVY5+XVIWl708usQjdesdFdikIdO0Fum1SujI5OdRcVSUtEyKoL+5tKo1WgxzlWW0vnT6Yg5Z9q6IEDwd9AljoWnoLX7dr4esRrGmVhuoP6wseyX8RvoCg5wwntTTsg/7TrUgShItwfjuqnJphbpur++LBTL6KBRt8wPTsJpVCP4zqwJarWNNMogndRakRVXxjku01KpiUyvXdhMPxHgJNfYo7a5KRs3BKEtVrbU1Gn3UKIf4ZyKRdoC69kzFrOhnK5wjXVcT/GdPA83o0EG+sf31gaV87Cuu/gJClERbfm7jQlnBjLDqKmGpAAPNHMI7Oo7ScuaWV039mjUZVRSbcUJnH9Dv+UP6Ix4pWo9g9L1BM4OkU70uH9+Wy8mIV3U/XoHnFB7H/BqVw35rsp5QG5H6IuqqyVVNWW9fNl41rC16bKgyDpNB8qn2KFWZbtsWJGr+aKUVudXybUGybRbM0JIhQhXlwuUqS1dYqj3C7bQlRE970wnAsRaEoUXE107qPVwD5vNTsapKuDadVQjUKDre5z6VtEVJzfI9o5du262kLH6WFdFTZIwSZlQQRTM3MreJlcPZF4lOwtUCrRzRqxrL3siM2gYZm1brCdirCuakPhhlRSkqygp+Xc6NfK9JT42+qmMjE5lNGUJxX6/e1MUVaT1TFc8tjMMlv26lMms7IB2BtG0bI4JZckfktK2MxGl00bl54jyWMdgWFYXFOWGZ6cdPIKK72eZRqbDYWk7G46Qwp6xjm+xa3DC75ga1MVSwKCtVntVKX0BZV3B/GB3aloyUpi0iktatksytWiusHN7Qnktlb4uW+v3ZHJVBK5OwgaK5CRi/jRZNzPJe2XJ6r7tpayV0T+apxyTTyi1GmmD2lKEcHtAXl72yf5SmeaxVf8SjkY6BIL/xOUSF8HfNz8T8Bna7SHV6nYoexhy5oxomgSgsenDY82u+HgrKWvIJb6yxTTGT13ZsUWGhDl8NsGC9fFJsvEFZUOuEVv3EBqzzXdTPfRXFqTfqg0Sg3EA22wE4jpL0/Fp9gvs21R7q5K0oLgRseRJL60ZyAi9ck1eP3E93jbRS9mxEFlB/K1cWS3NjBxuCPruPKMu3aMXc0o7xyJpoBTAn7Si5z/rMoV+oVFU8Rmr1a+bCsmeQmf5T82PFn9zpQctG0DCkazupp2PMrXrdzxnaIj9l4arJ7A8ahFzWdL+2onlEqSyK1RpGSchx7uBdiwsNUoegFucbDe4OGJyy8ixIRF3MD2XYK3PreY4FUsKoaEsjYx5LSLRkGTnBTXxkVhKNv0epkrc0oRFSQYh8mb9spWouIwQWIZpNWzsor+QKnIqPxgqTapJ0RgGqITgE86pdeceIKMsMp3rSx+yRrguttYT1Cb6I1kVkFM8hFiHRSv4+0lI9Wx8eRuMszDTHNaFP7ebtxghJMj5pLqIljehovDQSj7BDKxN1PxPRPKdpTS1MC9ijE6R5G+UMltpXjisToN7bx1jfYXXCS2tTz2OjbHgS49cF2D2jlJzo3zJComDkSKqMwarypqplWMSRTlkUIWoISB9fzyplUKoWz2n6+9eV6pRRSu4YD4T+UVoEszL1Sa6XE7sq3bdXIm/+6opWVSyHwuRNiLKOwJBKkLxSlEN8Xp7esedHh8AoQni1KodEwjBPNB8mcTxyn0a1oi4xsSE0uatbFg6o3AaZrE4n0RRECFAGacsoaVovqrI4h51oLKx3PHQiIWYjjRESZdqm1PpRWGSUZLiGipoYFmsi+qrxlMZK9ZSTGEbjEZE/fk99bUQxV34M34sOXTlK+sWW+jG4+kSXwBWJ5kAOtzqbKQTuUy1EZTEAVU0Z+Sq4HBQtQoYURwCntShK5s9DVMkttfD8QhWqiRaDRnOKFkdAHfGAEn5k+0jqLqm3mJG31DRGLOuUlWL7ay2qsGPR0Zi9lfnVk17NI0n6+PZBxosbufhW12jF8Sx1BIeLEo6YKpWpwqPCrxUlmE7qUeBphKhrlhmYPcqv9VlQi86qJQFRtlw3KUtPXy5DTU01f6Rim9aHbihm13Mrh9IqO6o3hnkuUVakkSJlWXM/mWEwZUWld6SKKsb0CShLrtA29i7pPbqyqjIKvXm+bnXOddHYj7VmbilKqiy0I8BXVv8YwDtFHqR5Tb2vwBVtGfmH1qHTJrpqkkWYyLmv1E7rY9ySD2qIm95ElrF3ak7zSR2xrTW5x33K1orNMbTUUyytErIjs/3Dz6111Q1iQ/B1mT8ipmQnjzJtCGEbbBNtKxAlQrypO0bPQUs3WENLimlSQERLUUZVTVWuvOQWy/0tklYOieTJjCcKr8p6Mob5pE7LR1B6xF7nMW9VaUtChTlE3dG3Uk34xiGBt1xRd3eE83WkgZZxot2mG9QYLHBED2l++QdUskqZH+rirn7Kw3nMr/nZVRS1hbqiDNmCpcIVK2rGBGotsCszAwSpSbbmFjFskZpalKGHM5prEZIAbHIZV8of7DulX7T2j4oLxVeoLkrq0dmUhasSO2NrncL4ekbJZQD3rbnOoHOWhlErrLjCMb/wsjfQAG8XMWfpRy32lmdnVX+1rFquVVeEH1CptbhftaKPDmvp+hI3CJ2XVaF7NDFHyOkUa6Olodh4Ws/wfr10Gi7b2i6CVmiDV9ZCv4WuNF60bOscGkVU0yckEgCMIVU/y5pySK6JjjWgDxXqyiSKgt51lRDV9uofXF/T7w6PC2v23AYa4Jv5eryHbe9Nc4dGBEMqOpWi2Ah+zTDoWdYROOU4Qjz2NMXFlOX7NBO34C1w+80blA+9IhjsxtWfGfIdWVqlpp0gse8KonTFnmEUcpHGyjphbFvUMIK5dA6JYJxQ+4DCyGFhwdVHZCT20+kc0mLNAbWRmnzBUcKRouWZckuqILAzczblu3juhMUn0l8hK7g7MpT1E2VtSDR/oO9aiDRVakMpiPfhv0XLzlFgXtrCx1uQplUjilIyb8cw01ZUTwyoTVmlMd2iQU/Fdf0si8/8rk5vvLW7a4aHfkbph75/ghPBPEdrm0kVR8x/uStK5DwezvGJnMCVLDky6jlaK0ScoZrIwZxii9bpmBMvnSa87M2lO55Q+gFnUP9+9uye/svubgBXvhuFr91RXCDYPc0IcEszA/H45Df8p7/U/ZbcdeYWxqUEp9c+pzpL6ZZbuVmfc7lRjjNl5bhe4Ijw5mreTnMjhwD1cTQofRVJXZnSt4sSfZj2mLw5gedGHxPrDIG9vxUREV9gh5lgeDtVUEQbcw7xv+JwKpRcwlMfqTlli9oxXGzOFW6MArNyRW87hsZwqx3VBbeN/vmrQkfaTu3P23mNxtrxvsLjeTtWkIYaKUgiRKVmbTC8ci7ToTqG9nm/C9NZdmxqpGhuoQ2XjkscJUzWUBkhut0RMbSWrxRLH6kvUsYO6hNukGOulz4SjB3K2t05ZNJE6BRBRE596q9T0mYYrg2/wbdjzc0QULqn8gUTeYRuhuEQdLsWhOIopBGiECIFUU7ZAYcT8DrPS1+gTOaa5lhzZYRobcZOof1+FJucSKW+sH6uqhzWAaXxpqbU5C7AKJgrvH8+FEZ2riWe+8M05jDY/goB0m9RIjmkVfgrqW/BULj2cqd2bO4AB1FP4SycQ/g7TdF2LWjIGK0YEadn2wjdbDymJt3OSU/5w403GcTJhJXh0LZg+4fGMxbb5HnpAcAl5mhgN9wDuLX+ee4lgDvr4Uj1GUV1Kv3NZb1tqD9TH7Pp1BwrlzKOzpW/l7mu2rEdMds/gqD9J+mbllahGRpHDf1SITDlkEPqu+EFSm24qS8B1KTgInPkKIGovxZueEF9B9IEQ3PNFRESkHJIWbBNTmD3dInV/i1o7MJVsRcxpAp9iZIuDpNBNskY3YIG2VZKo3qHbCvavG02I01SG1kkU37GuEfaj/tlc+jk/2GJzfM/JpeN05IpOZseEy4BHJFNQK9Ns82TP9Lkf6LwaPi3abToRTbrJcNN8iTAHhs5nh2QzYTpYtRT9t/ZOMwb4QQkc/w8uJ1G3Nn8YsR7hYxfTL7LaRZwMnmPJv9s4JTmbOoe5aZzD9rQz5Jl1Tfd4FyRegbyvg1KPwYwZ3nPoh4hoJtB45xVkTG6nFcEO7vpEsCD3eiZ7ISZK44AngAk7G2Ge/4lrXBFfY7dXz4+Cerq8e32mKOas4BXN2UOSafZk5gRfVuXnilrB2XPgdbeSN+B+rjC4v6CHS9lO+9XaD4XAPDKFO87MnH6jhtTvs/1TDuTfSSxG0q1s6+0gDkFu9c5hMtgO1aa1c4WIY8JuMnAzkIaluSzhfSVYdsZZR0y8AZOWRnIl+Oe6W7cb6Isp4A9ZkobjOISkB4d8pgEEw4YQ34EnOw8ki0hJhMoG/JEhZ7hGQDsDP+UG4lirwA82rnrkCz7ZsshKY16myjL8nC2eEumy/wI4Bbjl9pOmL4BlPAKwL1R0AXS9Px1PKUnO7uO0338aPKPEbKxHOK+4WYbzAf+AOARwA1Gr7oxc58wetpMWZ5/D5hLBHf2VwB+xVxY7DGTiolidG8/nS/44aK74oVB9ai59kUGGQTd7It5bcSbJQAPSITtDeYnHXxOHTDG2BvM5PgKktS93vmKudrSUu3Kxr04eZwMkobRII+2zdFmR5W4w60PhoMB+2qznlAfSk+2smMozkgO+gnAW5vEknJZs8dcoVR84dJ+scmPgsJL3UtbaK5PR7OMFfgewI+GebI3yrNreGDkou4SwP9CWbE8j+5QKIMMcpHnLXxr9/dr6vM09mrSxmuMhjjQ+r6vi/6J8Lph/s44HzAa4gozgXN2dfdkjTA0wC6+YLSqS/kawC+EzssN18gFPOmzvf+FlPyA0TjupiAIzhWTX7hnHkxozhcq9A8G1+liMxlkm8ra4RHAO9vu0lb31w8IXBM3JrY/BXBMn009F5hrny2Ae0iFBet8S9I+2k3vbUFf1Dd5rQvAOr9gpqWD3bi3BR8JhbruHIi/YTSC434iTbwiCLUmqPMHm/R3zHXGJS36Gyqq2AFfLYc4G7p73ttdV7aaM+pvmCNkfnrqRnjEXMU5ve9tJfZNngtgrpqcET1CvI8heJC6cQoUnoAYhWtDUbiRtgWEV6ZLhnBlsrwWCK+s71YhPJqq7gSCF3cbu0lgWIrZ2ZavMaezjW15LX0X1ncDfr7s1fw97edlgZvQ+w6Gy2t7ADOEB4OhEPYBhKcCAqG4NiSM4tqQMIrXtuFugvAracK3+0owuM9hFBA8/7kyNhjJhpXxCWPUgJTx6wiADoZXeTTnawAfMLvkxu7+gNEfbm23k/WN7WRYngD8DSN9sWF870fb4Q7AR0iEfLElX9tEhgDM7ntvMD4giJC3tvK9Tb5ASeQHzJXj30z9c4QAs0EcwgeUvvCL9bEminaygVuD8VGU4RA+miIcwsdpysUwJvWLPBrmSwau83g2uc/Amwz8mIF9Hs8ghzzW9lPFm+3xQT6MZ478I5AfgPwGyDdA/grkayBfAfnzeA7JW3sByNja6wIZV/a6RsZXZNwj4w0yHpCxR8Z7ZByQMdhrwvHBcB0y8N7wPhj+e5Pn2uS7Mnk/5fFREPJHw3NhGK8M81eT4Y3J9KPJeADyH01u1gUGZPzRMO6R8aNhv0fGjcn1xWS8sNd2vNcI9XIAPg/A7QDcDcD7Adh7ahrG8U8DcEPjTzSO4U/A8AQM74Hhxl6X9gIw/BkY9sBwBwy3wPDZxv7H17i01y0G3GHAewzYY8CfZfyGxp8w4E8ocIy43hvOG8N+SeN7Gr+txi8N261h3dsLwPBXG/9k8t2ZzE8QDE/2ujO8nwy7j+8N/53J+3ketwjZ5fF1ba+PGbjNwOcMvMvAnXnfQwZ+yuPDu59LrxgfwOWjedEDkD8A+Q7I78zjbs3jrseTb97x/f+NjB0y/mIe9BEZt8j4jIx3yLhDxgfztAdkHO2l3omjvX4yvB8M/zuT59bku87AX/Is+3i/43Kct/Z6Z687k+sByD+ZvD8rhp8N20+G9YPhf2fy3Nrr2l47ewE55Smv/psQIV//a2esbP8p1/+1MF5c9yCcB0NWPgtFsew3g6AwGhBSnnLZvwcrru0r23+8oG/VlssQzti1nvPtNLESAvUt/M/2uT30jNbZ6PeC8CwU3xwC8Exl/H/73dv/ARM9HTDOw93rAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABHNCSVQICAgIfAhkiAAABHRJREFUeJztnF9olXUYxz9H23Zi52wXtT+a2JQhMXbRVUkKgV6kG4pIeJEXg26FLAyyXWR1c4SESrxOwi6kCxF1syKSQMO6CcaIGkNNbG6zLnZ20M3Fvl3EhgmjHTzn+T1nPh/4XZyLc77P8374vZz3fX/vLyMhAjesSl1A8F9CiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDNCiDOeSF1AuZxjN1fYwi3WMcbaxQE88GmMddxiK5fZxfnEFZdHxvvKxRI5BujlDHsZpIcSubK+n2eaHgbZyxl6GCRHqUqVVggJeRzTyuk9faCcpiv2q3kVdUTvq6h88v6WGu6EzKpeH+tNtWiyaiktmtSnekOzqk/er2shw+pSl4bNErs1pBF1Ju/bpZBT2q8G3TNPzqmok+pL3r8bIdNq1H6dSn4o+nRSd5V9vIUMq0sbNZpcxsLo1pCG1J20imR/e+fJsJOLfMMrKeKXZAcXGaCXVYmuBpJdqfdTcCcD4Ct20k8hXQEppuWXejX56en/xmntezxOWRO0sokRijRbxpZNE1PcZD3NFE1zzU9ZBfrdywAo0kyBfvNc0xkyQSvP8juzZK0iH4kGZrhBB+1MmGWazpAjfFgzMgBmyXKUd00zzWbIdTroZJR5VlvEVYwGZviFLjZy3STPbIZ8zY6akwH/zhLLv+dmQs6yxyqq4ljWbnLKKpLnaf5kjvpqR1WFOu5TIkc9c1XPMpkhg/TWrAyAOer5ju0mWSZCfuU5i5iqcpXNJjkmQm7QYRFTVax6CCHLZEUJGafdIqaqWPUQQpbJihISLB8TIe2MW8RUFaseQsgyCSHOCCHOWFFCNnPVIqaqWPVgcnNxiiZauFOz97PquM9fPEXeYOW8yQxppsg2LllEVYVtXDKRAYbXIXs4axVVcSxrN3uEO8YanuEPIGMRV0HEbdaYLXQwmyFruc1BjlvFVYyDHDdddWK+DKgWFsktkKfIKJ20cscs0/ReVhuTvMUnlpGPRD8FUxmQ4KXPKZrYxAiTtFnGlk0Lk9xkPVlmTXPN7/Y2U+QzXifDvHX0sskwz+f0mcsA0r2FW9Dh5CvclxoFHU6WnkyIhHp0IfnBf3js0+mkFSTdOGCKJl7kR35zsirleX7mB17iSWaS1ZD0iWEzRX7iBbbzbcoyAOjlAt/zclIZgI+dHP7War2jo8kqeFsfaV6Z5MdBcvBa9IPjC72mOs2aJWZ1N9mrazUhRELXtEEHdELZKm4ikNU9HdAJXdOG5P26F7IwxtWmQzqmRpUq9quNKumQjmlcbcn7W2rUxPZMg/Qsbs80Tb6s7+coLW7P1MuA++2Z3At5mPPs4jJbl7WB2RausJtziSsuj5oTstKJlYvOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHOCCHO+AdScgYxkP93WAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "Image(100, 100, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)"
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
     "surface = skia.Surface(100, 100)\n",
     "canvas = surface.getCanvas()\n",
-    "canvas.drawImage(image, 0, 0)  # Draw something to canvas\n",
+    "canvas.clear(skia.ColorYELLOW)\n",
+    "paint = skia.Paint(AntiAlias=True, Color=skia.ColorCYAN)\n",
+    "canvas.drawCircle((50, 50), 25, paint)\n",
     "image = surface.makeImageSnapshot()\n",
     "\n",
-    "image"
+    "display(image)"
    ]
   },
   {
@@ -113,7 +114,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABHNCSVQICAgIfAhkiAAAB0BJREFUaIHVWktuHDcQfexpjWRJgAIvHAWw8wF0AR8g91/mAl5EcRAIChLEjmRrZtjNLFhFviqSGm3Txniaxfp/HqfbDglXO+DdCfAD2s/32OMav2PCLYDfANwC+JXuPwZg921h76kAvvks3Cp1a9Zb3OEtViPyI6l7uwJn9wMVtwA+AhO6Vyqf/KdSACD0hfoqGuLLLm+z3AxUzHkrDLYDgnP72WCGEb48gOE10i10CQTrMangqGmkO7jvMZE09TkKrUu0WmbkINaxoUzlnCZP82IJnUhDj1jWvnNG3M0ltiSQtFoP2lZgx31gDfuEI5U5fg2DUPe4h0IOZKnF4wY6Xp1nDfHaEF8GGc/u+j5HCSSFvhehOM7tpDqOjvCQgdORhmyG/oJhp4qwRA2qVyeT194wGsHRtNrU+oACb6wdBtqfgRQbKl0sP0wwl4uZu+dI72M4gq3XAFSc7hkIcexiGE7N5NbtXPB9GHyqDfa1m7g+2JX7GUC0O/ydmiTrdzefQ5xYnYSu+3DRhOu7kWniwAzgkDX34Kae7EcHu+eT8WRUkdbH4azwpsvDDCQJRFW1PdIzMmz/rnXP1LrcE+3aGMzJDIQ9EGaLQ60XHv2HP0+6EfeAu03Ji0+aDgO1FpNtVZKDyMbACE3K/drZbFWEYx3sZ4Uin4G0B7Dpe5XXEypKdcGjl0ozChNzN14lBIb54OtWohuhTEatcEA+FJ03mWPUDE1j+B9iqRm4dkk0TpTabCB+hBW5ItgBabahVvdXrEhSMO5042UgqzWgVP72TwkmFcFQ1s59YfCns0OtPYDFhlyNBPcQ2R32QbltpP4QCIZ1xFW+n+ttaa1dDoi9qvdJKuLnOYGek3s/RxQjzIlmGer32uyo6OTZPaN8nqlIKBTAltzQnulbi1p8mvPkVZse8Eo39ZDQdadUJBBqqfvViFbVj0GTHb4Ms+8LH5BNkB/4UhUPeqRuBkDw64cwmRlbzQ7p0kXtkNSUb3ilxj/OSZnvxijd54qkHZAmG3JVzWeIf3cU+IZLxulMHKm6xl4lMyGJdpvK+ygpuzrsU91R66lQQJSuAVaqnkx0322UChnM7gvZAEpJDgWHUhFONtcvc62tnF33UMAAUaINWw2fFj4EOeT28KJrrcPuuqZiBv+44MbTAqwrfNxWRTkEOBjWOBlMU71sY/LlglMRysm+TtbN/unDeTRoAlhxFliAgu7N2RHKnupjG3otHDvc5loCSYOK5ED8TxJzEKruEUKVPhkdyVmIdXNVGpe8DSpdZ9h7OWnNm10uvYegglqsYYhLpior0Yw+n8lckfWZilRjI/PmHPFnXmHwUKMb9mCYMFDVawu9ZLikIutkH35qDyfLb5KyCL1bjQ3cOeKDqCeTP+8nDFrLH2Y0lzOw7vPthqzXUd7QM1dwuspO72HCtAHrDO5jg2QYKPlQ10bIleF32qE8lHlUmQy/H8qSFP92h4OZ4CQW1FpmO4sgF6Oh2ltARdUsbmAdmMrLB4T8eqs9/yMiVszmmaZp1Q1Z5ag1yNIomusNrTcG0rnBi5pIcWseuMVyRRZBLW2rhdQuzYzovepZlMBHxYqal2ZG/IG4GrHej4NysntQ1cDyjEx721qzZGwFsMWMGScATmA73XS2RsatpWo2QO2FWTTxtNVAGERY3TyTYS0mt8diWotTqcZzRbiyIPNlLLS1IL6yF6syAHY2tBc3JW4N4gS1PwoccPa0O/W5Ns/IQoGwRznNieRUT6R1qKw1U4sLDAm1EgtJ5pSos2r94NQkzQE57jMrr4M0J+zBCYAFWzI/k3l2Bxuxrj7zGVKG3UPOXoTqsC9OTANLgM3kwTkQy4ykUKd1Ja9m7FAnRuU1KRpYiX8Rph3RSiB7J10rpOxa1JlEyz/e6ORv6J5waQb2hyqmnXpWanAqspcAtuSG6ngCiQG2wV+p0FYWGgBXKPfL1gWzRa3IqdpQBy5Q/z1a+n4GpgMQQ01pIJULHiXJX1HrFN039qi9kGC7x1QkuW+ltzprTwCPAC4W1Eo/kasx02dgilnhjnb0/xGc4QLAPwDOJbQt+azG8NQRPRWBC03hJESF4ShC2+J4Bf3MfY5cvwsgN4mKnqOWSoBmBv49ZKUqfgngi0hlV19RovcArgD8KXQAtd3PSfke5rVffWGzCpN687XY0PbS1zqJbSiUfanO40mcuS+puUJ5WMTfAH6S9WtAqFpiXd+LTmi2IoDPsj4Vjy44kAshnsr6swidAaLrHsA72X0kjwBxZRbHH8mpmF0WzP0E4I0YeS35uCoufCey70T+L+H+pAx/SILfyKaqeARdj0JUDVE0nAMkrh5osq5YhWQfO2FUFcgFisD7CFxG4C4C1xF4iMBNFNYIIP4CxAcgXgPxDoiXQPxA+3iPiEtE3CHiGhEPiLihfdyI3usI/Cz23kfgQ4TouhTd1/J5AOIN27gRvddi51LsEu7876//AJf5hDbJ0yZuAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABHNCSVQICAgIfAhkiAAAAg9JREFUaIHtmD9v00AYh39xUokCU2krt1IklCDUPwwFBOqH6EYXBgYkliAY4TvABiIDAwMDC6z9Cl2oFCHSdqChajtYKUoXoEhVsR4GlBHInc/OKdwj3eb3fn7sxPfelUBoBIiGfQOuCCK+EUR8I4j4RhDxjSDiG5W8Jn6vG/qsS0o0K0maVaK6OrqpjXwCQbgaO9Rp0CQm+eNVMyTc5wU71J3lgnAi8p2zPOA5Y5wMXDXGCQ95xjHjfoi0WWSBTesZFmizyfxwRdZZ5gw/Mj/Pc3xjneXhiBwyRZV9Bz+K36PKPodMFS9ymzfOJPrjDq+LFWmzSInUuUiJlC3L/4vVgvhUj0QOaymK9ESPrWpLYHb48FNlxerqSJNWgf/ignr6omlFhmcixo+1peu5SUjSkSb1QVeN64xFdlUzDjHlky4b1xiL9HunPLHJGJnu11gkVjeP+8icYSxyUXvGIUVkePn57SpWRalRnfEbqSjVitZMywZmRWvGEpLsNlZbzFPm1HmLUubUukWxEgFxl1fORe7x0rraWqTHBDU6ziRqdOgxUbwIiBZLjHOcWeI8X/nIlUyzZBIBscG1TBusKge0WMr8TjOLgOgyzS3eERnsUSJSVnmbaVfoXKQ/tpmjQZOZvxwHxSQ0aLLNnLNcEMYL4qAUfUCXm0jR/L/dr68EEd8IIr4RRHwjiPjGyIj8AuH5Z0Q/tKVbAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "Image(50, 50, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)"
       ]
@@ -123,9 +124,7 @@
     }
    ],
    "source": [
-    "small_image = image.resize(50, 50)\n",
-    "\n",
-    "display(small_image)"
+    "display(image.resize(50, 50))"
    ]
   },
   {
@@ -139,17 +138,29 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'RIFFd\\x03\\x00\\x00WEBPVP8L'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import os\n",
+    "import io\n",
     "import tempfile\n",
     "\n",
     "with tempfile.TemporaryDirectory() as t:\n",
     "    image.save(os.path.join(t, 'output.png'), skia.kPNG)\n",
-    "    image.save(os.path.join(t, 'output.jpg'), skia.kJPEG, 95)\n",
+    "    image.save(os.path.join(t, 'output.jpg'), skia.kJPEG, quality=95)\n",
     "    \n",
-    "    with open(os.path.join(t, 'output.webp'), 'wb') as f:\n",
-    "        f.write(image.encodeToData(skia.kWEBP, 100))"
+    "data = image.encodeToData(skia.kWEBP, 100)\n",
+    "bytes(data)[:16]"
    ]
   },
   {
@@ -158,12 +169,46 @@
    "source": [
     "## NumPy array\n",
     "\n",
-    "NumPy arrays can be directly used as a pixel buffer. Mount `numpy.ndarray` as `skia.Canvas`:"
+    "`skia.Image` supports NumPy array import and export via `fromarray` and `toarray` methods:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAGJJREFUeJzt0IENgCAQBEG0/56xCIUNcaYA2L8xAAAAAACAv7g2/DEXv//qhvurilMZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOAAAAANjtATuzATANtKc0AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "Image(64, 64, ColorType.kRGBA_8888_ColorType, AlphaType.kUnpremul_AlphaType)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "array = np.zeros((64, 64, 4), dtype=np.uint8)\n",
+    "array[24:48, 24:48, 3] = 255\n",
+    "\n",
+    "image = skia.Image.fromarray(array)\n",
+    "display(image)\n",
+    "\n",
+    "image = skia.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
+    "array = image.toarray()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, NumPy arrays can be directly used as a pixel buffer behind `skia.Canvas`. This approach enables direct drawing into the given array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -198,46 +243,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "NumPy arrays can be also used as a backend buffer for `Image`, `Pixmap`, or `Bitmap`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAGJJREFUeJzt0IENgCAQBEG0/56xCIUNcaYA2L8xAAAAAACAv7g2/DEXv//qhvurilMZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOqBmgDqgZoA6oGaAOAAAAANjtATuzATANtKc0AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "Image(64, 64, ColorType.kRGBA_8888_ColorType, AlphaType.kUnpremul_AlphaType)"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "array = np.zeros((64, 64, 4), dtype=np.uint8)\n",
-    "array[24:48, 24:48, 3] = 255\n",
-    "\n",
-    "image = skia.Image(array)\n",
-    "\n",
-    "pixmap = skia.Pixmap(array)\n",
-    "\n",
-    "bitmap = skia.Bitmap()\n",
-    "bitmap.setInfo(skia.ImageInfo.Make(64, 64, skia.kRGBA_8888_ColorType, skia.kUnpremul_AlphaType))\n",
-    "bitmap.setPixels(array)\n",
-    "\n",
-    "display(image)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "One pitfall is that generic pixel format is usually unpremultiplied alpha (`skia.kUnpremul_AlphaType`), but skia defaults to premultiplied alpha (`skia.kPremul_AlphaType`). Don't forget to specify `alphaType` parameter when needed."
    ]
   },
@@ -245,50 +250,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that most APIs in skia does not copy buffer data but only shares a reference. Therefore, buffer lifetime should be carefully taken into account when converting between different format. The following results in crash.\n",
+    "Many APIs in skia do not copy buffer data but only shares a reference. Therefore, buffer lifetime should be carefully taken into account when converting between different format. The following results in crash.\n",
     "\n",
     "```python\n",
     "array = np.zeros((64, 64, 4), dtype=np.uint8)\n",
-    "image = skia.Image(array)\n",
+    "surface = skia.Surface(array)\n",
     "del array\n",
     "\n",
-    "image.encodeToData()  # This will crash\n",
+    "surface.makeImageSnapshot()  # This will crash\n",
     "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Exporting a numpy array is easy via `numpy` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAI4AAACPCAYAAAAsoeOtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAAeh0lEQVR4nO1dW6wtSVn+/rXWIAwODAwj4aZMIjEhEi+ZoAnGoKhBJI4PhICGgGJ4AvEWAV/wQRNMjDoPRjNRDCYYBITIg+ESIg++kJlBEgQcnYxcZjLcEgYIkjBn79+H7n+tr776q7rX2vvstc9J/yf7dHd1ddXXVf/lq+rqXubuWGSRfWV1bACLXJuyKM4iB8miOIscJIviLHKQLIqzyEGyKM4iB8mZFMfMXmxm95nZ/Wb25vMCtcjlFzt0HsfM1gD+G8DPA3gQwN0AXununzk/eItcVjmLx3k+gPvd/QF3/y6AdwG443xgLXLZZXOGa58B4It0/CCAn+hd8BRb+bOxBoq/gKDpvT/gFIYToPq7kqShke+0VS1GWHOgbACYN2ppIcpQDYhW8DO10AbkDbJq92mkE+DeU3zN3W+FyFkUZ5aY2esAvA4Avt9WuAe3AHji+HfzuAXtP2HcvznJ90Q4ngAA+D9s8A0A3wDwyLiN/UcAfJPS0cj37TVw+oQGnLLa+pj3H/tdqiWrKdvX/I/A8C3ciEeram4mSNMtBDx+VITVtzowopHiOGukbwL2bf88EjlLqHoIwLPo+JljWiHufpe73+7ut99q1ilOuZZTmifnp3P0attLskqa1HCvzGeGNQtOr5EOhHYWxbkbwHPM7DYzewyAVwD4wPzL53ary/7wp6lXVRRq1RGOfjeemwqn0tSLOY10ILSDQ5W7XzGz1wP4EIbw+nZ3//TkhWYY0PIfZMvprNu79DlXFtWOJRU1G8FZIS9UK8sqTE+0Lm4hNvo3fS+9+6+qaVWZFayN1NC4M3Ecd/9XAP96ljKm5bRdv2yvmrTce1XxhSHav9ZzhrTMHC9ykFz1UVUpHBtavlKPp4NwKxhMpVsPTpbeihFNRL2L6/QsVEG2h7VQA+8UzE7BF6w4oJ4Cci4z1RR9nztFR1LF0QxoFKLHTSitCxRhWbkqTnY/rbSm7MvZ+PzlVJyWuk/td4qW/V53FYrT0tlZ3mUuqp4PqRVnCo5CasLziYt63ubSKE701u6gkSnbbxe5Twmpx5mrw7Og7XNhW3FaajYbxj7Q5nglkSN7HGDeHcS2HaamvG04llRxpgo4yPPse3+rVHFa+nywA1SImUe6dB4HmYlnPgGdc/Xd7GOZRekMJyv+4N7pzba1emnnczK8WdpO5Rpwe/bZqqCax8nlOB7HAl1sMe63UOd30LJl/uNGXaGsZbWSRIbTKlgrnoWshYrbYQXDavxXwlk3SlMIVV+7ZMpgRUV8nmE15OI5zqp16y1F0d6ZDlfZValhqQPM4GgDdvW5dw89tzb8tchx3HGm10AZbSbn+aYa6VJ7nMrbbE+i3eB1zti6pE85ie1fKE5WFcPz5HwXlZp6hk7RAMFuMh+lpU77YznZqrbXYJdHcWyID8auWt321J0OwtPsrWCgpVfrV9YjlDVl5rjAaVO9WaDhe8liod7/UIlhjQ1Ot/iye6gIPiZErYr3NVRxbOS1SYlcvMdZKb9p3c2sZplvecl1KTnOpOf/Cx4whaBl4nWo6ilG5scmq1NFabnjVZKeyPKsapGDZNLjmNmzAPwDgKdisL273P1OM3sygH8C8GwAnwPwcnf/er8wYDdVO8+j5IUkxcp+l9tEGnscPTknJuxFLnqkovQ4KqsxTQdALeiTkObAiVjZkDmh6gqA33P3T5jZTQDuNbOPAHgNgI+6+9vGV2PeDOBNk8hXK1IebgqO6upb8yZpBbq4iu+9yXHWkjmjXK0GThcmKodpcR7Q/oDIsMaKOM5u/XBZSc/s0pbKGik7bm0TmVQcd38YwMPj/rfM7LMYFqrfAeCFY7Z3APgYphTHMAzHLSOKPfXv34WG5Wxf+e0KI91SFsrVZFygNTQvZGo6lt3arh10HmeXw6tStORJ6VmY3l/WFiJ7kWMzezaAHwPwcQBPHZUKAL6EIZRl1+wWq683o8dZj0bU6mbunZyZWpKjpTyRp7J/w/CCQnYB63NLD5rCtfZQlQW25nFWIxhVKL3nFEZdWKkgbAytNz4Sma04Zva9AP4ZwG+7+zeNFp67u5tZ2sPufheAuwDg9u95nA+KA5Sqnd2ZHrcVKMvdGsqG+9+GqngNRuM6F5YNx5toMmQ9VLugZFhhjXUVOTMfrL46b/wEXmv+ArJlmInMUhwzuwGD0rzT3d83Jn/ZzJ7m7g+b2dMAfGW6IAy9Vdk+UCvMtFPWs1lODQq8v+Iqs7DUg6OVVons4xQJ76+3+61HDkyOgVKPlU2lCqS6yxcrEdxQ2lk8jg2u5e8AfNbd/5xOfQDAqwG8bdz+y1RZgGH3gIhvX++uZQaANk3LxtlR8LmiQ7iHMmfQUqSQ5prjjORr7zH6IX+Q49aALq7svUOROgnWqJ4BtLogkTke5wUAXgXgU2b2yTHtDzEozLvN7LUAPg/g5ZMlGYC1BtepYYwSjF3TxKAmo9cti+SQtR1V6VQtJHMLWtW4PR+YaWeEqd2oao3T6iVS9ZpqciyFUvU8aMZxNIKexeO4+783MALAi6auL8V25HjvngIYRkvtaje/O88dsoIMx7M+VfeeRZ7ioOUjsh6rUYfHaakZl9xqoUqmFCebszgPxTlXMYwcJ2vErNHVancTJ5m7ztpIjanolDXKvmXFgKRx9SWUBEkPUaZYoTiD6vSUv9VCRWvpi3h6T+zIVRv579IoDjD0VupxpnhB3Ut8v5DcLWMqDKoXqjIKxr04aeaKv+fWeALQydk5Bspc3p+am9aawlAjYKPRLtC2SKRzapFF2nLBocqAdcZEgJy1tVbalKl6Vq0wtmrzK0h16lE0hLWiaFUbUMaCjOfUlcRwfKqFQthROOid1zgxZwVr5kWzsC1y8aFq3WKjWSTPVKA8yrxxlKKhikPYGsMAz5QMZjB6kNK3/LXl1Siy2BCjKi8CWJa7x39SUR0OSGvUhRQN1CrwGB6nOaoKxJkaABnPaSlPtghKqUyhOD3KlSlNQOG5gBTJXI4zIGLFaS3k0tI92VZw9D504VqvkRpy8SsAY9mdt0y41fA6PBgkW+CmJUSaRp7VlHJkUCbJMQ+9WgVlAdSQzRwzOdbQlXkeA+CtCN+Ckbnpy+VxkJh5oNtg2sXXkrEHviJKj/bY8N8KOOU1DAwnI0Qtz5MqAqPjQrgSrnwDw6aa/BtKqJ+OM5zZX6nQZmWInK6uLpEjeRxtGqDsZg5bdC0dZ/caaa2RpnroQoczUqQmnllrITy5kwUWLlxR1cNxVX6NLtnzykoyr6IFqR7vdLkpx5kANEafMTO1YEDtSgMXLxPnx4vcbuqFK3Kc0Q/lCEDSU1PvH3ABmXbW5Liny0xVMh9dSUvxswouJccx9ThKGmI7z9RbIUrnpoGy27a1s8dpcRjqqYhK2xUlKe3SQMKGoMZS+pZQHHUIWeDLPIw6lyoTX5gRJG3EyxOqMJh56r65SbhH2OPUXid7g4m7rBV5VhgUx1u9pD1k2L7VU61BKxAZ6jGOKn5mJPWyiix3FpYmeU6vELZPbYdLozhmwCaCp3IcZSDZXVFRkkONKLPWqHW7XQGuPF3ZtCpTx333CUURJKmSmhxnn1jOStNwxQgA1EsHQBdmJEorPQ+OM36C/x4AD7n7S83sNgxfU78FwL0AXjV+Yb1XCsoJQPUJ2gR8t3VcUHtmFUSSVnUfK05mZdpDcis7OGrOmkm7WEnFsOVQ1Zta4lJ15WvheVYoGylTGqCuQDU2kY4zquSNAD5Lx38K4C/c/QcBfB3Aa/coa5FrXOYuHX0mgF8C8CcAfndcFfizAH51zPIOAH8E4K/7BWHkOC17ao0T2L7K4jLGkLlw9XGFx8k4zgaleXMhTMWa5CJjKepVy3GePnLgqiDHLcZUCA81gbpJA0LGcSY8ztxQ9ZcA/gDATePxLQAecfcr4/GDGF6ZqaR4y+HGG8dQlcUGZStA2RSc3l4XyF3TIsezQpUSp9WoK47yQwWFz1bmxfeU9UhJKoZ3x5HyHCQlsakxgvQgU36d9GRuc1aOY2YvBfAVd7/XzF44lV+leMvhlqf4QI4ZnaJWeptHcA7fGQdQPdB5rZg5doWSwQFKKCmh4AQdtmR/UWipOL3c2iJKYSqPE5BUh9XztKzujB7nBQB+2cxeAuCxGH6D4k4AN5vZZvQ66e84pNL1OOqg6zuOj/ErKVROy/cP2i+8joYqddtZw6pH8kADStBA0lMcDVUy15Tkbjm8iJw+ZrCWW4YUrqFqBjmes+b4LQDeAgCjx/l9d/81M3sPgJdhGFnNe8vBDPkj6UCtjazm0X46npWQDfar4Xi4H7UyjferoUMsq3grMf5lM8/+slAVw3Gr+k6H4zrI0+C4FY2YGt84ZNVwzoXjZPImAO8ysz8G8B8YXqGZlm2oalmfWisry65Z2LaBskG1VC59khyvpcCMHDOAqpZs8iTjPpF/Z0DqcXo+Wf1ZBQnSQHGSLYkbrIZzforj7h/D8I443P0BDL+SN1/ikUPaU9ywkDQgWwDDObM12VmbFN44FGcqLkRh3DMZ3HTFlHZ35gcHVKw4veiZedSU42ii3ovG+SqWa4E7OcKzqiQGAKj9pwbfumladGSaTZDiKBz1LuO54nMoRTwAam3ScTAXmIUqnjm2IlJkTjAL4tomlWh8ixDFISkbQTTk4p9VbXQIk/mE6abIBgtqidroGsJPguPoyApSQIuNpqiU57DfUGMptVY9Tit3jxw3G4kdHjezht9MvxM54tNxZqRAjZibqfY43DVA3hbc6Kwf8bdVnNZwfCzIbYSsnVCRCu5KDsF6f6oKAwDDZvw/pxrcEkqOY1vByTLFlsNWq5EacqSHnFmo0l7hbZwvX8jTEK1tktHQQj1XRI7V+tRKWW9dtmnQYCStAJpznF4wVweR8Z/mC3l8P2qX2kiXiuMAyF8tAOpunY7g3I/KlFqBkA3qNBRnA+AGgUNQ3JB/CyryFUjU53FPMbJAuzNvw8nIdHZnVM303linmx5HlYPvLyoChm+vcdjuaEc3Yi+ySEuOGKoye8rCVrZUa2ddakw6SlZ/Vo2q1NEpBB2+6HmAMKodZnFAA0wdqlrkmO+RPUycT8nxCmVjaejNwnNWsciRl442YkPFQGtyXBSLuj9DNWOBkCrNNlS1yHG8dLEehuzGOsw6nc64cW9xL0SvcWxYgclxNhyPe9tISayK3BZbYY3KiH023td43pCLX6y+UZvK1F2tMsSLvYwUq/dhj8P8YJbHyUZSbSdICbpcXk2dUW4APAr1OIo3u79IY/NK9VhtL7PRaKRsOJfIJXo9Rs1AR1bDef2smVqfGpB20QnVvDEix9nD+hGSY3CW6eyABXa+B1ZbvUArYQAno/qUwXxqUFSNrrRJezrM2qgu+QRNOfJwPOM4GnhC8sXqGr51TKMMg73xaShONvbNNFEHet1lFfqgSD0t3/Oux0JxVo3cmR6kr/+G8K9vZ/rdGnqyfidyxFDVW48D1MpTsNFifjZjQy3vE4a0wTDM7s4cTzmPqrdUfbML9J434HHwhj7lxlwNqJVJvU2qPKrsyryzLuAuasjcpaM3A/hbAD88YvsNAPdh30/yR6hKPQ472xbtryWL9ep1gNretx4n6w29gArOf6ZIu4sZGN+PGkdF1xG/HsPRM6NdfO8Mu6BdmTVdkQbKyHFYF3srkbke504AH3T3l5nZYwDciOEDkvt9kr8IVZmH2SBvJg1ZZYrS6Rb11vDtBvgNdAFbGXsYhsmVVy9eqCtSVp0ZSx6qWoEt82fcDhU55pO8n9mlWlbbXmctHX0igJ8G8BoAGF+B+a6ZHfZJ/uLpeKtZFDUHpl1K0WcojSpzIOqdtx6HdTbjOGTO+e+UM5IsTKnShIlz4BxMPAtVGj0VVua3CyigjJlBqAOM6HnGUHUbgK8C+Hsz+xEM71C9ETM/yV8Ke5zoKY7gmTXGtlQVdc2ZEWmo0lHVluPoU0UusOXSU2mZOHe3dnlp5mtYs18zxqS+uFAcnTZQdxUQVrJviMjZlDmKswHw4wDe4O4fN7M7MYSlHb7OJ/mLtxyefItwHO2pzKayu6XyUTaskkXVg8LjAKXCZPGelcewG+pWKLgWRqM+kI3lFKWJO9bicdQ/qfppjQ5sv49T/WauKssaO0uKtgiFcXQVpxPFtvIggAfd/ePj8XsxKNKXx0/xo/dJfne/y91vd/fbb73ppizLItegzFms/iUz+6KZ/ZC734fho9ifGf9ejX0+yW9IyLGauEbrjMm0QxUbUzbwZRuH0XA8IxQ9045tykZbFFaPOc8Gg8cpJwC1RabgVNL77kEGLwvNicwdVb0BwDvHEdUDAH59LHrPT/Ibyjc5M0XJWGmIV3s6zab9zedUXT3IcdZL2ohjYdbtrYxxccgKIhwxYI1dTBi2G6yqoThzV1WYTBULUZwcnoIAMxwNVw2ZpTju/kkAtyenXjTn+p2YeBxulkhv8ZqSCmbGk01TMD/gR46Fx2mR44zLZqZetDC7odbIinvxlNI3WI/zOIxfOVymQEj2m8+qhLdVLi0qPod5nPOR7dPx7HF0ZuJ9e8q8L1NRvvdiNBXp1nnkoLqtChT76copxV8ryCCn49/uwRD/fDTD4hbKQlb8Fe+BRALDYnhKjsO6TumvIUd65JDZkypOa0hQc5xMebibQGnRNuvx4uKRQ9ZLGRwFUNl8q2u5MEYVIQwFx8l0uUe7tq2ksawFS61L0y6N4gAo36tqMTOg7Ix2sK1Vqo4sWvo2PThOdaJTcMptFKeGrp72cU8Nv92gHkchZbDSFlIYWggrE1DqcXijhhwxVIXLZhPnhtQ0gHtLnwhn3veUSgoDinM3ADiJUJVxHJ5JZj1PJRtNtUgF94iSYxQcJyAxI9LomQdxgdPzNidUSKSFW76hdb9HWVahYUpRg46btK/pDLLgwKXHDW8XaXCIYsqlOsxpqs9dVHwv8acoQq2HpVysIK1o0wpT3ZUeWQEaqjjen3VUda6y5p7SrgVKG2PHDPCaHCeuo9bGDZ6Nb6JdYGi/Asw9t0bd96CCUwXnHmLGlZGKSHfwV0dZn/m+GELKAPVRwwrlcPNU4PE987KnS6M4VahiJVFlysgGFUV/ZdMPfxuUbRA3egOVZtZZc5zREnX9zYbNujZTHEeJEtDvHHMwbw30Wjq9rf40OZFxHI2Bl2bNMUbFqabixnNVU6g32sUGnfjjtNbLeto+sLHLtCBN432deXSgNnGuPUjEqWzjfHm//GX1tZSW1aD60A1VWfNmDTMRpiLrIovsLUd+y0HHDEZb9aOljYUts4fhkVSEq0epdKBc3GZRPIcqXsgVr8hkMaGAFQcnKLFrMM1IRYStIZ6s4BUcZX8c0NUZVpQrjpX06sQWw1ljUo7DcdJ5UW0SdYblsa58iTDOXbWd6KNrIn07V8u9ofOR2uesMF0CqW+/abxYUz6eRa4n+Yxys6kpBY/9IvTGRSeSxjA4cmYN1pAjTQCqkgC1WXOakgvAYCkZZILMbRKKxQa2rU7fdFM4kVc5b6QXs0nMZRgdKwvn5ydog8fh0ZTqcgaN4VXcw+lEVHfauIC9jSqRyJE8TsttZ6ORdKxQrXZTr8NpUTqPuK4ApeUxMYxzav6R3mKmKTrusWwYEz00nI9QlXkX9UTa7+X4TDK6HKs7A+3PCFdz33L4HQC/OVb/KQzLKp6Ggz7Jrz2i4x72RpDzu2ZkH5R1C6sjsLPr7UJ1YPeVLe0R0HGvt7b5VYMYER9rj2i3G2ycoeJAno2WWakqOJmwFbGji6oVzhWIFpYyZ7H6MwD8FoDnuvt3zOzdAF4B4CUYPsn/LjP7Gwyf5J/xZXWOC8E+A7XGivagjz1wa62Sepy4rqDlrbjAeqzEKc6nY19lH+wH2aQzVKWyZJD0j2tNIUWhEUF5SagqTjg+HbckMjdUbQA8zswexfBqzMM46JP8hmEhlzJOSFpBIFAq0K7noqEyL7zG7jW3uErbwzhz5qpaHId1wwEYm+ypZGCN02f2fD8DQv2FPIXAkTSDUwlrU2Rgvq6eZ0XXnEVx3P0hM/szAF8A8B0AH8YQmmZ9kr+SdXgZ3gJlM3Fjr5PtcPYK5QJ2SsRX8uPEkKJddGZAOQ5QapvqdBGqVGni4pgEzNS5nChQ2sUeZy1bJc2sA1sIjPtEtnpBDM9jZeBZno6b2ZMA3IHhNZlHALwHwIunrqPrd285PP3pMzxOL0bsul9dsnIcr64ojWhrdEqMtTd0WomtsPI4ymkyz8NzN9w7Qx4bPY7Sq8jBSqN60ZQshmcch98fmpg5nhOqfg7A/7r7VwHAzN6H4TP9sz7JX/yWw/Oe59vhuI93YNRTMQkRC3t97Bnj84OYjf3mu2MAWPloUDYGB9+WPqwxHtNWY1VYCRSuekVQxnNbKMb1DgdOBHc4tvH/1fbscH7X3T6quJEXGvxwTDc4KUu8c+VbNYuao2Sn46JhIi0aZuXj1nbZo2Gioc44j/MFAD9pZjdiCFUvwvCDZ/+GQz7Jvwq7UT4D5LPGOe3Lxiyg3LHPRhVBg0dWBcdRE1ZLZW/D8bHyOGravbQYaQ2mblulyGlW5pO7oyptqJPkOHNXvKQ0ka6HA4Dxfar3AvgEhqH4CoMHeROG3666H8OQfN4n+Re5LmTuWw5vBfBWSd7/k/wAkWP1OOp9lGS2KX6Udir7PBzXEWnYejqY40Iz8+bttnQQAm9sAwU/ZtjQdbvHDlod0IbTHQCxl2EiGNXzlsVwyZaOrgDYusNxIk2JhFWhO0L1CXacx0ZKtApuQhwn8pyM4X1tVG1QqxHONm0CilGPlRMFwTdW237ykZEaXbFjK+vxmpgAtFFBnBSnTAtOs5Kat0gM2P7kDTfMKXbhdUU3sL3OugvVgaMuVlfioHYFOgaSwebWRtmzRN+HkUWYDuOJ0k8gF+hoSqFlPAfJcXFCvc2WhVKe8C+7J2tKuXiGQEvWCcJKmE4xp2H3q03syJq7kCN4HKV6LWrHzaPKtBNWGk3nSdIYYbICVdXqfE0GSd19JRwH4gJFxRVygN3lVYLMkLQm3U/hZJC08TS2n3FUdb6yolBU9EBGJDIbs21Ka7zCjIFLYG6zbZdWldlx17RV2GcwyeDeYC2MYXmux1EiO8bMERZ8hw/4pnXWmK2raqBcjqA4meNFss9mEcd1qIp2UNveVkdXa95tbVnEBGXKXHnqdRTRKcre0WG7Ko4VZxVaJnxl1UIBgQvVj0nyRbwOLeA15AjLKlq20joGGt1ddINOV3A6l8BhvfA4+8BJzbuHiMOtN/INiDI4LQgKp1IyT7asLEGSFI5yn0SOtB4HqFGpI460LG95ldotG5kaGIevreKEZMNxPjcNh5AwoeghAqV5CifzyT2+UxSQxW2N5y3oHbn4UGVAMQRPb7/lP8q74RxZIOCrlVlovkpR5sSIZqL6+JZ2Rg/WszEMJ4uiQOmrupB60bIHpyNH4jgtftN0upOiTIGZRkgRoiAeR6ucig9NFMzNNAYwkkhnpfHJKrMQpftNWNxILAon0i4Vx1n17Ei7WVWh9jiteaqsjdLSMqKQwclgpSFLiUVWmHrW8pq5kLJBQQU54zlz4GQKRtKN1oss0pLjcJxyhyQz4/7kibIKzpXR0JTftKpueZXJuBBbZZnqH1tkuV1NltZtIY6Ec+AAnUbayRFfj1FpoeyPC3uDgOwVoYws7wVnEhKPlLQQXvkXkiKaz1+m4EQBc+EEpEtFjs2wW+ibZpiZVkrrPluxv2ZLe0Cazdl7qFrjo/3hzIa0D5wZcpxHDk054A46V7b43exaDoezZwHz8l0VOAc20hE4zplvf7/qLrS2OXL5EB0Cydwngtk5ipl9C8PPFV2P8hQAXzs2iKsgP+Dut2riRXuc+9w9+17yNS9mds/1em+ZLPM4ixwki+IscpBctOLcdcH1XaRcz/dWyYWS40WuH1lC1SIHyYUpjpm92MzuM7P7xx9/vWbFzD5nZp8ys0+a2T1j2pPN7CNm9j/j9knHxnk15UIUx8zWAP4KwC8CeC6AV5rZcy+i7qsoP+PuP0pD8Ddj+FXk5wD4KOTnJ683uSiP83wA97v7A+NXu96F4QsY15PcgeE7QRi3v3JELFddLkpxngHgi3Q8/3s6l1McwIfN7N7xMy7AQb+KfO3KxT+ruj7kp8YPTn0fgI+Y2X/xyd6vIl8vclEe5yEAz6Lj5vd0rgVx94fG7VcAvB9DKJ71q8jXi1yU4twN4Dlmdtv4g7CvAPCBC6r7XMXMHm9mN8U+gF8A8J8Y7ufVY7ZXY873gq5huZBQ5e5XzOz1AD6EYd3Z29390xdR91WQpwJ4vw3LQzYA/tHdP2hmd2PfX0W+hmWZOV7kIFlmjhc5SBbFWeQgWRRnkYNkUZxFDpJFcRY5SBbFWeQgWRRnkYNkUZxFDpL/B9G3cyQm/fQtAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 144x144 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "image = skia.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
-    "    \n",
-    "array = image.numpy()\n",
-    "\n",
-    "plt.figure(figsize=(2, 2))\n",
-    "plt.imshow(array)\n",
-    "plt.show()"
    ]
   },
   {
@@ -300,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
@@ -325,8 +295,8 @@
     "canvas.drawCircle((64, 64), 32, paint)\n",
     "\n",
     "plt.figure(figsize=(4, 8))\n",
-    "plt.subplot(1, 2, 1), plt.imshow(canvas.numpy())\n",
-    "plt.subplot(1, 2, 2), plt.imshow(surface.numpy())\n",
+    "plt.subplot(1, 2, 1), plt.imshow(canvas.toarray())\n",
+    "plt.subplot(1, 2, 2), plt.imshow(surface.toarray())\n",
     "plt.show()"
    ]
   },
@@ -336,35 +306,40 @@
    "source": [
     "## Converting image from/to PIL\n",
     "\n",
-    "It is possible to directly convert `skia.Bitmap` or `skia.Pixmap` to `PIL.Image` using `fromarray`. Note that `PIL.Image` supports limited image modes, and most of the color types in skia are not compatible.\n",
+    "It is possible to directly convert raster `skia.Image`, `skia.Bitmap` or `skia.Pixmap` to `PIL.Image` using `fromarray` method. `skia.Image` can be convertible when the image is in raster format. Use `makeRasterImage` or `convert` methods for conversion to the raster format.\n",
     "\n",
-    "For `skia.Image`, first export to `skia.Bitmap` and then convert to `PIL.Image`:"
+    "Note that `PIL.Image` supports limited image modes. Apart from `skia.kRGBA_8888_ColorType` format, many pixel formats in skia are not compatible.\n",
+    "\n",
+    "Default alpha type of `skia.Image` is `skia.kPremul_AlphaType`. To convert `skia.Image` to `PIL.Image`, make sure to first convert the alpha type before calling `fromarray`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "skia_image = skia.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
+    "\n",
+    "pil_image = PIL.Image.fromarray(skia_image.convert(alphaType=skia.kUnpremul_AlphaType))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, use `RGBa` (premultiplied alpha mode) in `PIL.Image`:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAV7klEQVR4nO1d23IcOXI96G6S4kjUaiRvKHZjHuZP7J/wV/on7D/xw4Z3FSGtNeJwSPal4IfKrDo4SKCqSY42NsKI6GE3gEKevJ3MqqY4KePVHfD2GvgDxtc7lO/fNebH9xlv8Rt2+AXALwC+2k/+/FXm9f3dFhjehseX4nle973aNxC0UJRrCbf4AYem9i0IDOP1CdjcngmD338DNmiOZD9ze8vCyM+6unHg4kjy+eUQRPqotC6M3Fij0XGIiuYTa2j91S6GdSM6PLT16o3PgrIIoWeMDhxxyBqzZXmfq5nfZbQCf1K4Z6Znh0M4QpuvMUYHzk7PW75qI3uS/XdR1ho85WJvIwtM0eTvP7oQ1sKQPR3Kao0hnP19yCEQ0BX4u6NYhhBtOGN0MuRpSp1Lek8e3WT4vhnykuMJlKWjLu5Lo3nyUzz1fZLhPNHP8FTHIf+A8X0C+/cfz7Dmi1NWa3yXTuyfcYgxdkB+BmWtN+25zUf3gBcf3yE1V0bkDkhnZIgCT8HcM0cL7FlptbT5jDu1zjirn1g5z5SVuzuBessZclujOjH1Fl9A4JkXrb2VmPadi7mmLAxo3VwsnrYWQTtjV5vmH1Twc0f0WXVxpQGkqD9N6zVBverk3hOPsx4sPo2CXoQtGUZrbuHRiWdIbidKH9KL3R/3kq/n0epB0vMD61mj91x2Ya9nyFBDalmjbfZnd1K943venh4ALUl9GqpnZb1vXDKtzXmG5CfwQxfWi/Qxz3pS+WIPGvOzTlh7se0jysoruqxzJJRXrMqeXgXVffw+bNUy/Tx/pODtWZqvLWedLouWVJH1fdFSs8wnF1iiW5onc8Xzq5oY41kHVGNdUU8Un72YXlfge+shmUT9BH85sOY+tVo49wYxHBOyVW4+N8ODtpco65yvu553k1itRcf2ErPLRr3+WefPb5W74Rkd0ztaAtEdcirF9fh3fWvJV2sChBh7nUCLzlYVpFZsr6oxWU9jsV13tvqKTeM9qjt1Bbh0h9OEUo1tY75bR9YwZY4+8EG9dmK5NvIpPf6ovnrt+XqBsk6YMmSNcTXWN9OVa/JqAU/7olXj3Odv9X5130Bzve+7V1FXtNagLOmy9Kp+C5wwgmWy06v4tKZiLepvHbq6/1kK1Tz9Nwoc/7n6OUaLqlo60AE7IFmGrHWpzudVmcmj8n6rbPl77bZy8L44rDVaHk/FJ11Zak6mdfWgilOPqoMSsAOGAUje9q4Y/a6kp1RXyahKuoPU8N0sWUtRms/VKVN4aP+g8VCcEBi5iTVoYixD8mm+QsW2WsP1XdaSTYvIUe1b6R/ORSQZub/dSfbqXwQtg+Bvgs29ztE/l5TFbS+vLvFIPXq3CuzSkGlah/RGpXTk8vOoOGpKWi5FMN88Ws0aHYa5ywoeMEZXM4csR1dECF4O+oSxMDT1Fn/dr4esRrGmVxtoPuwsey38RuYCh5ww3qmn5Rh2SbUiawiNFfC2stqwRry+rw5YimEO2eYXpmE3qxD8Z+Yje5HW8SY5xIs6l+AWVcUSW22urqu5UqsT6BYeWsuKO8litwtozMWLSzpOC2HFb8zRoBqScpxnrd4zFbuin610jmxdbfCfPQs0s0MX+cL2rw8s1WM/cfUvIERFtBXnti6UFewIu64Sliow0M4hvKITKK1gbkXVNK9VM8oQfV8fxTGgv+cPmY94pBg9gtH3Bs0ckk71uXz7ttxORryq8vgE3lNEHPNr1A77pclmQmtE5ouoqy5Y6spafDn41LC36LGh6jhMDsmnOqLUZCq2rUg0/NFKK3Or49uKZBMW7NCWIUIV1cLlLktPaNFauLk1EqKnvekE4FgrwtAi4usX9RauAfP9U3Gqari2nFUI1Cm63uc+1bRFSc32XdvwhSKu+7iGFMDmXfyTJZQwo4Yo2rmRvU2snM5+SHQnXB3QqhG9rrGcjdyoY5C16bSegr2uYC7qg1FWVKKiquCfy71R7DXpqTFXTWxkI7MpQyiu6/WbergirXeq4XmEebgU161SZmMHpCOQtm1nRDBL7oiCtlWRuIwuBjdvnNcyBhNRUVhcE5aZfvwGIrqafR61CoujFWS8TgZzyjq2ya7FDXNoblA7QxWLqlIVWa3yBZR9Bc+H2aFjyUlpEhGRtIpKsrcarbRyeEN7L7W9LVrqz2cLVAatTMIOivYmYPxttGhjlvfKltN7laajVdC9mKcek0wntxhpgtkzhnJ4QF/c9or8qEzzWqv/iFcjGwNBfeP7EFXC3zW/E/MLOOwi0+nnVMww5igc1TEJRGHRg8NeXPPnoaCspZjwwRbbFDv5bMcWNRYa8NUCK9arJ4XgDcqGWje0+id2YOPoQKzPVRSn0agPElmIZhNGhxxHTXpxrTHBc5tKhgZ5K4sLBVuRxNq6k5zAi9Dk06PwU6mRVcorNqILz7dqZXE0Dw6wIZiz64iyXEQr55Yk9mNwaW4q2lFxn+2Zw7hQrap8jMxaI1aXDbLTf2p9rPiTJz1p2QlsAPGq3amnY8yt+rlfM9bQJCtXbeZ40CTktqb7aytaR5TKolytYZSEHNcOllp80CR1COpxvtDg7oDBKSvPikTUxfxQpr0yt97PsUJKGBVtaWbMawmJjiwzJ7iIb5mVROPfo1TNW5bQDKkgRLHMv2ylZi4zBJYhWk1bEpRXcgVO1UfjhMk0SSajBNX0G4J9lVSWGOVwWeHUTvqYPbJ1YbWWsr7BD9G+iJziNcQyJDrJ30dWqnfrw8NonZWZ9rgl9KndLG7MkCTrk+UiWtKMjtZLJ/EKB7QyUfc7Ea1zWtbUw3SAPTpBmsUoZ7DWfnIdsq2S6mts77Dm8NE6NPLYKRvexPj1AA7PqCQn+m+ZIVEyciZVzmBT+VDTMiziSKcsyhB1BGSOP88mZVBqFq9p+u+vK9NFXcFsmfGG0L9Ki2BWrj7J5+XCrkZ38UrkzX+6ol0V66EwWQhR1hEYUgmST4pqiO/L0zuO/OgmMMoQPq2qIZEyzBPNh0mcjzynWa2oS0zsCC3uGpZFACq3QTZr0Ek2BRkClEnackqazou6LK5hJ1oL+x1PnUiJ2UljhkSVtqm1fhUWOSUZrqGiJobFloh+1XgqY6V5yk0Mo/GIyB+/p741opwrv4bvZYeeHBX9QqR+Da4x0SVwRaI1kNOtrmYKgefUClFbDEBNU2a+Ki43ipYhQ4ozgMtalCXz9yGc2j4XmYX3F6ZQS7QYdGlPIwPqjAeU8CPfR1qrA4q5FjOySC1jxLJOWSn2v/aiCruWq4N3b2V/9aRX60iSOb68oji+kJtvDY1WHs9aR3C4KdGMqYp65PMSfZwlmO7UW37Xxk9vEsrC7iv+WTOmRWfVkUDpDP3cpCy9++KS2yP2GXmSqxiaEjqCvVVAaZcd9RvDvJcoK7JIUbJseJzMMDI0+WfztExR5Zg+AWXNFdrG3iW9Rk9WU0apN+9XUed8LgbHsfbMLUNJl4V2BvjJGh8DWFIUQVrXNPoKXJHIKD60D52E6KlJDmEi57nSOq2vcUs+qCFuehtZx95dc5rv1BH7Wot7PKdsrdgcQ8s8xdGqIQcy+z/83lpPVeyKsq4fEVNykEeVdoLNim2DTQyDs7usIZwhrEirlLmEMgzW0BJ/LgIjoqWooqqlqlCO6kIryzWbylklaeWQSOfqkF7JimBgvlOn4yMoPWJvqRa0tqRUWEM0HF2UWsIFhwSubm9Jd4Tz58gCLedE0qYLlOtY4Yge0vzyL6jklLI+1M8p6qc8+jxNn11pxlQBE1XIFixVrjhRKyZQW4FTixkgKE0imkfEsEVpalGG3pzRXsuQBGCTyzhX/uDYKeOiJT9qLhRfYbqoqEf3pqxcVdgZW+sujD/PKLkN4Lk1nzOobGgatdKKOxyLC297AwuwuIg5yzhq0aZmjs5Xx6rnWn1F+AWVeovnI0LV5wvtRI0yJyR0PlaV7tHEnCGnU2yNloVi50mzUMjrldPw2Ja4CFphDT5ZG/0WutJ50bGt+9Aoo5oxIZkAYEyp+lnWVENyTXRsAX2oUHcm9CeFqrxqFcciS9T3Gh/cX9O/HR4P1uq5DSygSEvrDahdqbUjStYqUaOizU7wzwyDnmUdgVOOM8RzT0tcTFnRA0alMcdbxayD3KDs4SMYHMbVnxlyiaytItsREt97rDTrtTm8t4gjvVPwsUUNI9hL9yERX5xQhqXDKB/eRY0Fdx+RkzhApvuQFmsOqJ3U5AvOEs4Ubc+UW1JxlRdpF6PGV7hbF88wlDIiWhDaIsryLguYH+i7FSJLldZQ2mQ5/LdodX3CvCyivmWmZ0DzBiYdPUDbiTqHB9Suim4AWuuhiAY9ReuUIcwBbi4fLNrDNcNTP6OMQz8/wYlg3uNS9NtuHDH/5a6okPMa7/HDp41Mhuw9tphmTKmlsmSr6eP1sLAzlAiCO6PMEJyAIZfRdEIZB1xB/fez53D2f+zuDnDju9H5swfKlux5dE25JvBnDkddn+KG//SXht9SuM7cEjGmZkRE4NOIRG7l4i1qSJvREE5Zua4VDk8J3M28nfZGAQGaY+pU+iqKujKli4sKfVj2mLy5gOfGHBPrDIGjv5UREV9gh5lgWJwaKKKNMkNSHk+YjVzC0xipOcUjnjG42lwr3BkFZtZ6SRxDY7iVRA3BbWN+Js8jiVP/szjv0dg6PldEPItjA2mqkYEkQ1RrtgbDK/dq59RSmTG7Mp1jx6FOivYW1nDtuMVRwmQLlRmi4o6IobVipTj6SHORMXbQmHCHHHN99JFg7FD27s4hkyXCoAgycprTeJ2KOsNwa/gFLo4tN0NAGZ7KF0zkEboZhkNQcS0Ixa2QZohCiAxENWUHHE7A6zwffYGymHNv6WWbi3wtT7FpNniGHEFBpFpf2Dx3Vw7rgNJ501Bq8hBgFMwVPj/fFEZ+rjWe58My5jDY/woBMm9ZIjUkuh125tRWZ4bCvZcHtWPzADiIeYpg4RrCv9MUiWtBQ8boxYg4vdpG6GbnMTWpOCc95Q933uQQJxM2hkPbgv0fOs9YbJPnowcAl5izgcNwD+DG5ue9lwBubYYz1XcU3anMN4/1saH5THPMptNwrNzKODo3/l72umnHcUTZkisEnT/J3HS0Ks3QOGvoHxUCUw05pH4YXqC0hrv6EkBNCq4yZ44SiMZrEYYXNHcgSzA0t1yRIQEph5QFE3ICh6drrP5vQeMQrpq9iCFV6UuUdHGYHLJJxuiWNMh2UhrNO2Q70fZtszlp0trIIpnxM0YZaT/KyxbQyRTIts//mFw2Tktm5Gx2TLgEcEQ2Bb03zbZP/kiT/4nCo+HfptGjF9m8lww36ZMwMsSMZwdkc2G6GO2U/d9sHGZBOAHJAj8P7qcRd7a4GPFeIeMX0+9y2gWcTN+j6T87OKW5mnpEues8gvhxRMmyGpvucO5IvQL53AZlHAOYq7xXUc8Q0MWgda6qyBhDzjuCnV10CeDeLvRKdsLMFUcAjwAS9rbDI/+STriiOX7AtKX1SVE3j4vbY85qrgLe3ZQ1JJ3mSGJGdLGufURZQ4HBWcSp04niQHPcYfF8wY6XgTiv1829r8zwLpGJ0yVuzPi+1yvtTPaRxu4otc4eEhOu9KUc67Gi4txA7llMGfKQgDcZ2FlKw4p8tpS+Mnk7p7Zslpgoy6Ik/TrKmyjLKWCPmdIGo7gEpAeHPBbBhAPGlB8BJ7sfyVYQkymUDXlAWQOAneGfaiNR7BWAB7vvOiSrvtlqSEqj3SbKsjqcLd+S2TI/ALhB9XfaE14BuEPGEcAF0vT8dbxLT3bvOu739aPpP2bIxmqIx4a7bbAY+AOABwBvMEbVG3P3CWOkzZTl9feAuUXwAH4F4FfMjcUeM6mYKkb39tP5gh8uenheGFTPmms/ZJBF0MV+mPdGLCwBuEcibG8xP+ng+9QBY469xUyOryBF3fudb5i7LW3VrmzdaeVhckgaRoc8mJij7Y46cYdb3xgOBuyb7XpEfVN6spOZ2iaHOOhHAO9sE2vKbc0ec4dS3Ri6tl9t84OgcHK9tIPm/nR0y9iB7wH8aJgnf6O8dw1vGLmpuwTwv1BWLO9HdyiMQQ65yLMIF+3xfk1zXsZeTdZ4jdERBzrf5brqnwmvO+bvjPMeoyOuMBM4V1cPT7YIQwPsw1eMXnUtXwP4hdB5u+EWuYAXffb3v5CR7zE6x8MUBMG5YooLj8yDKc31QpX+weA6XWwmh2xT2Ts8AHhv4i7tdH/9gCA08cbU9qcAjumLmecCc++zBXAH6bBgk+9I2we76IMd6Ie6kNd6AGzyK2ZaOtiFezvwgVBo6M6J+BtGJzjuR7LEK4JQW4Imf7BNf8fcZ1zSob+hoood8M1qiLOhh+edXXVlpzmj/oY5Q+anp+6EB8xdnNP73k7i2OS9AOauyRnRM8TnGIInqTunQOEFiFG4NRSFO2lbQHhltmQIV6bLa4HwyuZuFMKDmepWIHhzt7GLBIaVmJ2JfI25nG1M5LXMXdjcG/DzZe/m70ietwXuQp87GC7v7QHMEO4NhkLYBxAeCwiE4tqQMIprQ8IoXpvA3QThV7KEi/tGMHjOYRQQ3okxNhjJho3xGWPWgIzx6wiAbgyv8ujO1wA+Yg7JjV39EWM83Ji0k82N42RYHgH8DSN9sWNc9oNJuAXwCZIhX+3I17aRIQBz+N4ZjI8IMuSdnXxnmy9QEvkBc+f4N4zmnzMEmB3iED6ijIVfbI4tUYyTLdwYjE9iDIfwyQzhED5NWy6Gsahf5NExXzNwncd7k7sMvM3AjxnYZ+Bgr8G73Yyxb88DkA/jPUf+Ecj3QH4L5DdA/gbkayBfAfnLeB+St/YCkLG11wUyrux1jYxvyLhDxltk3CNjj4wPyDggY7DXhOOj4Tpk4IPhvTf8d6bPtel3Zfp+zuOjIORPhufCMF4Z5m+mw1vT6UfT8QDkP5rebAsMyPijYdwj40fDfoeMN6bXV9Pxwl7b8Voj1MsB+DIANwNwOwAfBmDvpWkY1z8PwBtaf6R1DH8Chkdg+AAMb+x1aS8Aw5+BYQ8Mt8BwAwxfbO1//IxLe91gwC0GfMCAPQb8Wdbf0PojBvwJBY4R1wfD+cawX9L6ntZvqvVLw3ZjWPf2AjD81dY/m363pvMjBMOjvW4N72fD7ut7w39r+n6Z1y1Ddnl8XdvrUwZuMvAlA+8zcGvRd5+Bn/J4p/5zGRXjA7h8tCi6B/JHIN8C+b1F3I1F3PV455t3fP1/I2OHjL9YBH1Cxg0yviDjPTJukfHRIu0eGUd7aXTiaK+fDO9Hw//e9Lkx/a4z8Jc86z5e77gc54293tvr1vS6B/JPpu/PiuFnw/aTYf1o+N+bPjf2urbXzl5ATnmqq/8mRMif/7WzVo7/lM//tbBefO5BOA+GnHwWiuLYF4OgMBoQUp5q2b8HJ66dK8d/PGNulchlCGdIrfe8nCVWQqA5/7+4NEZuLz1hdAR9LwhPQvHiEIAnGuP/x3cf/wcXFBcpGVYsnAAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<PIL.Image.Image image mode=RGBA size=100x100 at 0x117217210>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "skia_image = skia.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
-    "\n",
-    "bitmap = skia_image.bitmap()\n",
-    "PIL.Image.fromarray(bitmap)"
+    "pil_image = PIL.Image.fromarray(skia_image.makeRasterImage(), 'RGBa')"
    ]
   },
   {
@@ -389,7 +364,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Importing a `PIL.Image` is a bit involved. The easiest is to use encoded bytes:"
+    "Importing a `PIL.Image` requires conversion to supported color type:"
    ]
   },
   {
@@ -399,17 +374,21 @@
    "outputs": [],
    "source": [
     "pil_image = PIL.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
+    "skia_image = skia.Image.frombytes(\n",
+    "    pil_image.convert('RGBA').tobytes(), pil_image.size, skia.kRGBA_8888_ColorType)\n",
     "\n",
-    "with io.BytesIO() as f:\n",
-    "    pil_image.save(f, 'png')\n",
-    "    skia_image = skia.Image.open(f)  # This ensures the image is immediately decoded."
+    "skia_image = skia.Image.frombytes(\n",
+    "    pil_image.convert('RGBX').tobytes(), pil_image.size, skia.kRGB_888x_ColorType)\n",
+    "\n",
+    "skia_image = skia.Image.frombytes(\n",
+    "    pil_image.convert('L').tobytes(), pil_image.size, skia.kGray_8_ColorType)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, the following function demonstrates how to directly copy pixels from `PIL.Image` to `skia.Image`. In the following, the internal pixel buffer of `PIL.Image` is exported by `tobytes`, and directly mounted by `skia.Pixmap` with appropriately configured `skia.ImageInfo`. Then, `skia.Image` is constructed from the `skia.Pixmap`."
+    "Alternatively, it is possible to use encoded bytes:"
    ]
   },
   {
@@ -418,26 +397,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def convert_image_from_pil(pil_image):\n",
-    "    COLORTYPES = {\n",
-    "        'L': skia.kGray_8_ColorType,\n",
-    "        'RGB': skia.kRGB_888x_ColorType,\n",
-    "        'RGBA': skia.kRGBA_8888_ColorType,\n",
-    "    }\n",
-    "    assert pil_image.mode in COLORTYPES, 'Unsupported mode %r' % pil_image.mode\n",
-    "    info = skia.ImageInfo.Make(\n",
-    "        pil_image.width,\n",
-    "        pil_image.height,\n",
-    "        COLORTYPES.get(pil_image.mode),\n",
-    "        skia.AlphaType.kUnpremul_AlphaType)\n",
-    "    pixels = pil_image.tobytes()\n",
-    "    assert len(pixels) == info.computeMinByteSize(), 'Pixels do not match the expected size'\n",
-    "    pixmap = skia.Pixmap(info, pixels, info.minRowBytes())\n",
-    "    return skia.Image.MakeRasterCopy(pixmap)  # Ensure to copy; otherwise buffer might goes out of scope.\n",
-    "\n",
-    "\n",
     "pil_image = PIL.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
-    "skia_image = convert_image_from_pil(pil_image)"
+    "\n",
+    "with io.BytesIO() as f:\n",
+    "    pil_image.save(f, 'png')\n",
+    "    skia_image = skia.Image.open(f)"
    ]
   }
  ],

--- a/src/skia/Bitmap.cpp
+++ b/src/skia/Bitmap.cpp
@@ -1022,23 +1022,18 @@ bitmap
         :return: true if alpha layer was constructed in dst :py:class:`PixelRef`
         )docstring",
         py::arg("dst"), py::arg("paint") = nullptr, py::arg("offset") = nullptr)
-    .def("peekPixels", &SkBitmap::peekPixels,
+    .def("peekPixels", &PeekPixels<const SkBitmap>,
         R"docstring(
-        Copies :py:class:`Bitmap` pixel address, row bytes, and
-        :py:class:`ImageInfo` to pixmap, if address is available, and returns
-        true.
+        Creates :py:class:`Pixmap` from :py:class:`Bitmap` pixel address, row
+        bytes, and :py:class:`ImageInfo` to pixmap, if address is available.
 
-        If pixel address is not available, return false and leave pixmap
-        unchanged.
+        Raises if pixel address is not available.
 
-        pixmap contents become invalid on any future change to
+        :py:class:`Pixmap` contents become invalid on any future change to
         :py:class:`Bitmap`.
 
-        :param skia.Pixmap pixmap: storage for pixel state if pixels are
-            readable; otherwise, ignored
-        :return: true if :py:class:`Bitmap` has direct access to pixels
-        )docstring",
-        py::arg("pixmap"))
+        :return: :py:class:`Pixmap`
+        )docstring")
     .def("makeShader",
         py::overload_cast<SkTileMode, SkTileMode, const SkMatrix*>(
             &SkBitmap::makeShader, py::const_),

--- a/src/skia/Canvas.cpp
+++ b/src/skia/Canvas.cpp
@@ -394,7 +394,7 @@ canvas
             independent fonts
         )docstring",
         py::arg("bitmap"), py::arg("props"))
-    .def("numpy", &ReadToNumpy<SkCanvas>,
+    .def("toarray", &ReadToNumpy<SkCanvas>,
         R"docstring(
         Exports a ``numpy.ndarray``.
 
@@ -535,9 +535,11 @@ canvas
         py::arg("origin") = nullptr)
     // .def("accessTopRasterHandle", &SkCanvas::accessTopRasterHandle,
     //     "Returns custom context that tracks the SkMatrix and clip.")
-    .def("peekPixels", &SkCanvas::peekPixels,
+    .def("peekPixels", &PeekPixels<SkCanvas>,
         R"docstring(
-        Returns true if :py:class:`Canvas` has direct access to its pixels.
+        Creates :py:class:`Pixmap` from :py:class:`Canvas` pixel address, row
+        bytes, and :py:class:`ImageInfo` to pixmap, if :py:class:`Canvas` has
+        direct access to its pixels.
 
         Pixels are readable when :py:class:`BaseDevice` is raster. Pixels are
         not readable when :py:class:`Canvas` is returned from GPU surface,
@@ -545,16 +547,14 @@ canvas
         :py:meth:`PictureRecorder.beginRecording`, or :py:class:`Canvas` is
         the base of a utility class like DebugCanvas.
 
+        Raises if pixel address is not available.
+
         pixmap is valid only while :py:class:`Canvas` is in scope and unchanged.
         Any :py:class:`Canvas` or :py:class:`Surface` call may invalidate the
         pixmap values.
 
-        :param skia.Pixmap pixmap: storage for pixel state if pixels are
-            readable; otherwise, ignored
-        :return: true if :py:class:`Canvas` has direct access to pixels
-        :rtype: bool
-        )docstring",
-        py::arg("pixmap"))
+        :return: :py:class:`Pixmap`
+        )docstring")
     .def("readPixels", &ReadPixels<SkCanvas>,
         R"docstring(
         Copies :py:class:`Rect` of pixels from :py:class:`Canvas` into

--- a/src/skia/common.h
+++ b/src/skia/common.h
@@ -30,6 +30,15 @@ size_t ValidateBufferToImageInfo(
     size_t rowBytes = 0);
 
 template <typename T>
+std::unique_ptr<SkPixmap> PeekPixels(T& peekable) {
+    std::unique_ptr<SkPixmap> pixmap(new SkPixmap());
+    if (!peekable.peekPixels(pixmap.get()))
+        throw std::runtime_error("Failed to peek pixels, perhaps not raster.");
+    CHECK_NOTNULL(pixmap->addr());
+    return pixmap;
+}
+
+template <typename T>
 bool ReadPixels(T& readable, const SkImageInfo& imageInfo, py::buffer dstPixels,
                 size_t dstRowBytes, int srcX, int srcY) {
     auto info = dstPixels.request(true);

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -320,11 +320,11 @@ def test_Bitmap_extractAlpha(bitmap):
     assert isinstance(bitmap.extractAlpha(dst), bool)
 
 
-def test_Bitmap_peekPixels(bitmap, pixmap):
-    assert isinstance(bitmap.peekPixels(pixmap), bool)
-
-
 def test_Bitmap_peekPixels(bitmap):
+    assert isinstance(bitmap.peekPixels(), skia.Pixmap)
+
+
+def test_Bitmap_makeShader(bitmap):
     assert isinstance(bitmap.makeShader(), skia.Shader)
 
 

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -72,11 +72,12 @@ def test_Canvas_accessTopLayerPixels(canvas):
 
 
 def test_Canvas_peekPixels(canvas):
-    assert isinstance(canvas.peekPixels(skia.Pixmap()), bool)
+    if canvas.getGrContext() is None:
+        assert isinstance(canvas.peekPixels(), skia.Pixmap)
 
 
-def test_Canvas_numpy(canvas):
-    assert isinstance(canvas.numpy(), np.ndarray)
+def test_Canvas_toarray(canvas):
+    assert isinstance(canvas.toarray(), np.ndarray)
 
 
 @pytest.mark.parametrize('args', [

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -18,12 +18,23 @@ import numpy as np
     (((100, 0, 4), np.uint8), skia.kRGBA_8888_ColorType, ValueError),
     (((10, 10, 3), np.float64), skia.kRGBA_8888_ColorType, ValueError),
 ])
-def test_Image_init(args, color_type, error):
+def test_Image_fromarray(args, color_type, error):
     if error is not None:
         with pytest.raises(error):
-            skia.Image(np.zeros(*args), color_type)
+            skia.Image.fromarray(np.zeros(*args), color_type)
     else:
-        assert isinstance(skia.Image(np.zeros(*args), color_type), skia.Image)
+        assert isinstance(
+            skia.Image.fromarray(np.zeros(*args), color_type), skia.Image)
+
+
+def test_Image_frombytes(png_path):
+    from PIL import Image
+    pil_image = Image.open(png_path)
+    image = skia.Image.frombytes(
+        pil_image.tobytes(),
+        (pil_image.width, pil_image.height),
+        skia.kRGBA_8888_ColorType)
+    assert isinstance(image, skia.Image)
 
 
 def test_Image_open(png_path):
@@ -44,8 +55,8 @@ def test_Image_save(image):
         image.save(t.name)
 
 
-def test_Image_numpy(image):
-    assert isinstance(image.numpy(), np.ndarray)
+def test_Image_toarray(image):
+    assert isinstance(image.toarray(), np.ndarray)
 
 
 def test_Image_bitmap(image):
@@ -130,8 +141,7 @@ def test_Image_makeShader(image, args):
 
 
 def test_Image_peekPixels(image):
-    pixmap = skia.Pixmap()
-    assert isinstance(image.peekPixels(pixmap), bool)
+    assert isinstance(image.makeRasterImage().peekPixels(), skia.Pixmap)
 
 
 def test_Image_isTextureBacked(image):

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -16,16 +16,12 @@ def test_Surface_init(args):
     check_surface(skia.Surface(*args))
 
 
-def test_Surface_numpy(surface):
-    assert isinstance(surface.numpy(), np.ndarray)
+def test_Surface_toarray(surface):
+    assert isinstance(surface.toarray(), np.ndarray)
 
 
 def test_Surface_repr(surface):
     assert isinstance(repr(surface), str)
-
-
-def test_Image_repr_png(surface):
-    assert isinstance(surface._repr_png_(), bytes)
 
 
 def test_Surface_width(surface):
@@ -93,7 +89,8 @@ def test_Surface_draw(surface):
 
 
 def test_Surface_peekPixels(surface):
-    assert isinstance(surface.peekPixels(skia.Pixmap()), bool)
+    if surface.getContext() is None:
+        assert isinstance(surface.peekPixels(), skia.Pixmap)
 
 
 @pytest.mark.parametrize('args', [


### PR DESCRIPTION
- Introduce `frombytes` `tobytes` methods to `Image`
- Remove `Image.__init__` in favor of `Image.frombytes`
- Rename utility functions used in Image.cpp
- Change the signature of `peekPixels`
- Unify the implementation of `peekPixels` by template