### PR TITLE
Surface and Image APIs refactor

### DIFF
--- a/notebooks/Python-Image-IO.ipynb
+++ b/notebooks/Python-Image-IO.ipynb
@@ -306,7 +306,7 @@
    "source": [
     "## Converting image from/to PIL\n",
     "\n",
-    "It is possible to directly convert raster `skia.Image`, `skia.Bitmap` or `skia.Pixmap` to `PIL.Image` using `fromarray` method. `skia.Image` can be convertible when the image is in raster format. Use `makeRasterImage` or `convert` methods for conversion to the raster format.\n",
+    "It is possible to directly convert `skia.Image`, `skia.Bitmap` or `skia.Pixmap` to `PIL.Image` using `fromarray` method.\n",
     "\n",
     "Note that `PIL.Image` supports limited image modes. Apart from `skia.kRGBA_8888_ColorType` format, many pixel formats in skia are not compatible.\n",
     "\n",
@@ -339,7 +339,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pil_image = PIL.Image.fromarray(skia_image.makeRasterImage(), 'RGBa')"
+    "pil_image = PIL.Image.fromarray(skia_image, 'RGBa')"
    ]
   },
   {

--- a/src/skia/Bitmap.cpp
+++ b/src/skia/Bitmap.cpp
@@ -1022,18 +1022,23 @@ bitmap
         :return: true if alpha layer was constructed in dst :py:class:`PixelRef`
         )docstring",
         py::arg("dst"), py::arg("paint") = nullptr, py::arg("offset") = nullptr)
-    .def("peekPixels", &PeekPixels<const SkBitmap>,
+    .def("peekPixels", &SkBitmap::peekPixels,
         R"docstring(
-        Creates :py:class:`Pixmap` from :py:class:`Bitmap` pixel address, row
-        bytes, and :py:class:`ImageInfo` to pixmap, if address is available.
+        Copies :py:class:`Bitmap` pixel address, row bytes, and
+        :py:class:`ImageInfo` to pixmap, if address is available, and returns
+        true.
 
-        Raises if pixel address is not available.
+        If pixel address is not available, return false and leave pixmap
+        unchanged.
 
-        :py:class:`Pixmap` contents become invalid on any future change to
+        pixmap contents become invalid on any future change to
         :py:class:`Bitmap`.
 
-        :return: :py:class:`Pixmap`
-        )docstring")
+        :param skia.Pixmap pixmap: storage for pixel state if pixels are
+            readable; otherwise, ignored
+        :return: true if :py:class:`Bitmap` has direct access to pixels
+        )docstring",
+        py::arg("pixmap"))
     .def("makeShader",
         py::overload_cast<SkTileMode, SkTileMode, const SkMatrix*>(
             &SkBitmap::makeShader, py::const_),

--- a/src/skia/Canvas.cpp
+++ b/src/skia/Canvas.cpp
@@ -305,10 +305,8 @@ canvas
     .def("__repr__",
         [] (const SkCanvas& canvas) {
             auto size = canvas.getBaseLayerSize();
-            auto imageInfo = canvas.imageInfo();
-            return py::str("Surface({}, {}, {}, {}, saveCount={})").format(
-                size.width(), size.height(), imageInfo.colorType(),
-                imageInfo.alphaType(), canvas.getSaveCount());
+            return py::str("Canvas({}, {}, saveCount={})").format(
+                size.width(), size.height(), canvas.getSaveCount());
         })
     .def(py::init<>(),
         R"docstring(
@@ -535,26 +533,25 @@ canvas
         py::arg("origin") = nullptr)
     // .def("accessTopRasterHandle", &SkCanvas::accessTopRasterHandle,
     //     "Returns custom context that tracks the SkMatrix and clip.")
-    .def("peekPixels", &PeekPixels<SkCanvas>,
+    .def("peekPixels", &SkCanvas::peekPixels,
         R"docstring(
-        Creates :py:class:`Pixmap` from :py:class:`Canvas` pixel address, row
-        bytes, and :py:class:`ImageInfo` to pixmap, if :py:class:`Canvas` has
-        direct access to its pixels.
+        Returns true if :py:class:`Canvas` has direct access to its pixels.
 
         Pixels are readable when :py:class:`BaseDevice` is raster. Pixels are
         not readable when :py:class:`Canvas` is returned from GPU surface,
-        returned by :py:meth:`Document.beginPage`, returned by
-        :py:meth:`PictureRecorder.beginRecording`, or :py:class:`Canvas` is
+        returned by :py:class:`Document`::beginPage, returned by
+        :py:class:`PictureRecorder`::beginRecording, or :py:class:`Canvas` is
         the base of a utility class like DebugCanvas.
-
-        Raises if pixel address is not available.
 
         pixmap is valid only while :py:class:`Canvas` is in scope and unchanged.
         Any :py:class:`Canvas` or :py:class:`Surface` call may invalidate the
         pixmap values.
 
-        :return: :py:class:`Pixmap`
-        )docstring")
+        :param skia.Pixmap pixmap: storage for pixel state if pixels are
+            readable; otherwise, ignored
+        :return: true if :py:class:`Canvas` has direct access to pixels
+        )docstring",
+        py::arg("pixmap"))
     .def("readPixels", &ReadPixels<SkCanvas>,
         R"docstring(
         Copies :py:class:`Rect` of pixels from :py:class:`Canvas` into

--- a/src/skia/common.h
+++ b/src/skia/common.h
@@ -30,15 +30,6 @@ size_t ValidateBufferToImageInfo(
     size_t rowBytes = 0);
 
 template <typename T>
-std::unique_ptr<SkPixmap> PeekPixels(T& peekable) {
-    std::unique_ptr<SkPixmap> pixmap(new SkPixmap());
-    if (!peekable.peekPixels(pixmap.get()))
-        throw std::runtime_error("Failed to peek pixels, perhaps not raster.");
-    CHECK_NOTNULL(pixmap->addr());
-    return pixmap;
-}
-
-template <typename T>
 bool ReadPixels(T& readable, const SkImageInfo& imageInfo, py::buffer dstPixels,
                 size_t dstRowBytes, int srcX, int srcY) {
     auto info = dstPixels.request(true);

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -321,7 +321,7 @@ def test_Bitmap_extractAlpha(bitmap):
 
 
 def test_Bitmap_peekPixels(bitmap):
-    assert isinstance(bitmap.peekPixels(), skia.Pixmap)
+    assert isinstance(bitmap.peekPixels(skia.Pixmap()), bool)
 
 
 def test_Bitmap_makeShader(bitmap):

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -72,8 +72,7 @@ def test_Canvas_accessTopLayerPixels(canvas):
 
 
 def test_Canvas_peekPixels(canvas):
-    if canvas.getGrContext() is None:
-        assert isinstance(canvas.peekPixels(), skia.Pixmap)
+    assert isinstance(canvas.peekPixels(skia.Pixmap()), bool)
 
 
 def test_Canvas_toarray(canvas):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,6 +3,10 @@ import pytest
 import numpy as np
 
 
+def test_Image_buffer(image):
+    assert isinstance(memoryview(image.makeRasterImage()), memoryview)
+
+
 @pytest.mark.parametrize(['args', 'color_type', 'error'], [
     (((100, 100), np.uint8), skia.kAlpha_8_ColorType, None),
     (((100, 100), np.uint8), skia.kGray_8_ColorType, None),
@@ -31,10 +35,13 @@ def test_Image_frombytes(png_path):
     from PIL import Image
     pil_image = Image.open(png_path)
     image = skia.Image.frombytes(
-        pil_image.tobytes(),
-        (pil_image.width, pil_image.height),
-        skia.kRGBA_8888_ColorType)
+        pil_image.tobytes(), pil_image.size, skia.kRGBA_8888_ColorType)
     assert isinstance(image, skia.Image)
+
+
+def test_Image_tobytes(image):
+    assert isinstance(image.tobytes(), bytes)
+    assert isinstance(image.makeRasterImage().tobytes(), bytes)
 
 
 def test_Image_open(png_path):
@@ -141,7 +148,7 @@ def test_Image_makeShader(image, args):
 
 
 def test_Image_peekPixels(image):
-    assert isinstance(image.makeRasterImage().peekPixels(), skia.Pixmap)
+    assert isinstance(image.peekPixels(skia.Pixmap()), bool)
 
 
 def test_Image_isTextureBacked(image):

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -68,6 +68,10 @@ def test_Surface_generationID(surface):
     assert isinstance(surface.generationID(), int)
 
 
+def test_Surface_notifyContentWillChange(surface):
+    surface.notifyContentWillChange(skia.Surface.kDiscard_ContentChangeMode)
+
+
 @pytest.mark.parametrize('args', [
     (skia.ImageInfo.MakeN32Premul(120, 120),),
     (120, 120),
@@ -89,8 +93,7 @@ def test_Surface_draw(surface):
 
 
 def test_Surface_peekPixels(surface):
-    if surface.getContext() is None:
-        assert isinstance(surface.peekPixels(), skia.Pixmap)
+    assert isinstance(surface.peekPixels(skia.Pixmap()), bool)
 
 
 @pytest.mark.parametrize('args', [


### PR DESCRIPTION
- Support `tobytes` regardless of Image format for better PIL interoperability
- Revert peekPixels signature
- Add RefCnt inheritance to `Surface`
- Add missing `notifyContentWillChange` to `Surface`