### PR TITLE
Add missing gpu APIs

### DIFF
--- a/src/skia/GrContext_gl.cpp
+++ b/src/skia/GrContext_gl.cpp
@@ -1,0 +1,61 @@
+#include "common.h"
+
+void initGrContext_gl(py::module &m) {
+
+py::enum_<GrGLFormat>(m, "GrGLFormat")
+    .value("kUnknown", GrGLFormat::kUnknown)
+    .value("kRGBA8", GrGLFormat::kRGBA8)
+    .value("kR8", GrGLFormat::kR8)
+    .value("kALPHA8", GrGLFormat::kALPHA8)
+    .value("kLUMINANCE8", GrGLFormat::kLUMINANCE8)
+    .value("kBGRA8", GrGLFormat::kBGRA8)
+    .value("kRGB565", GrGLFormat::kRGB565)
+    .value("kRGBA16F", GrGLFormat::kRGBA16F)
+    .value("kR16F", GrGLFormat::kR16F)
+    .value("kRGB8", GrGLFormat::kRGB8)
+    .value("kRG8", GrGLFormat::kRG8)
+    .value("kRGB10_A2", GrGLFormat::kRGB10_A2)
+    .value("kRGBA4", GrGLFormat::kRGBA4)
+    .value("kSRGB8_ALPHA8", GrGLFormat::kSRGB8_ALPHA8)
+    .value("kCOMPRESSED_ETC1_RGB8", GrGLFormat::kCOMPRESSED_ETC1_RGB8)
+    .value("kCOMPRESSED_RGB8_ETC2", GrGLFormat::kCOMPRESSED_RGB8_ETC2)
+    .value("kCOMPRESSED_RGB8_BC1", GrGLFormat::kCOMPRESSED_RGB8_BC1)
+    .value("kCOMPRESSED_RGBA8_BC1", GrGLFormat::kCOMPRESSED_RGBA8_BC1)
+    .value("kR16", GrGLFormat::kR16)
+    .value("kRG16", GrGLFormat::kRG16)
+    .value("kRGBA16", GrGLFormat::kRGBA16)
+    .value("kRG16F", GrGLFormat::kRG16F)
+    .value("kLUMINANCE16F", GrGLFormat::kLUMINANCE16F)
+    .value("kLast", GrGLFormat::kLast)
+    .export_values();
+
+py::class_<GrGLTextureInfo>(m, "GrGLTextureInfo")
+    .def(py::init<>())
+    .def(py::init<GrGLenum, GrGLuint, GrGLenum>(),
+        py::arg("target"), py::arg("id"), py::arg("format") = 0)
+    .def_readwrite("fTarget", &GrGLTextureInfo::fTarget)
+    .def_readwrite("fID", &GrGLTextureInfo::fID)
+    .def_readwrite("fFormat", &GrGLTextureInfo::fFormat)
+    .def("__eq__", &GrGLTextureInfo::operator==, py::is_operator())
+    ;
+
+py::class_<GrGLFramebufferInfo>(m, "GrGLFramebufferInfo")
+    .def(py::init<>())
+    .def(py::init<GrGLuint, GrGLenum>(),
+        py::arg("FBOID"), py::arg("format") = 0)
+    .def_readwrite("fFBOID", &GrGLFramebufferInfo::fFBOID)
+    .def_readwrite("fFormat", &GrGLFramebufferInfo::fFormat)
+    .def("__eq__", &GrGLFramebufferInfo::operator==, py::is_operator())
+    ;
+
+py::class_<GrGLInterface, sk_sp<GrGLInterface>, SkRefCnt>(
+    m, "GrGLInterface")
+    .def(py::init([] {
+        sk_sp<const GrGLInterface> interface = GrGLMakeNativeInterface();
+        if (!interface.get())
+            throw std::runtime_error("null pointer exception.");
+        const GrGLInterface* ptr = interface.release();
+        return const_cast<GrGLInterface*>(ptr);
+    }));
+
+}

--- a/src/skia/GrContext_mock.cpp
+++ b/src/skia/GrContext_mock.cpp
@@ -1,0 +1,28 @@
+#include "common.h"
+
+void initGrContext_mock(py::module &m) {
+
+py::class_<GrMockTextureInfo>(m, "GrMockTextureInfo")
+    .def(py::init<>())
+    .def(py::init<GrColorType, SkImage::CompressionType, int>())
+    .def("__eq__", &GrMockTextureInfo::operator==, py::is_operator())
+    .def("getBackendFormat", &GrMockTextureInfo::getBackendFormat)
+    .def("compressionType", &GrMockTextureInfo::compressionType)
+    .def("colorType", &GrMockTextureInfo::colorType)
+    .def("id", &GrMockTextureInfo::id)
+    ;
+
+py::class_<GrMockRenderTargetInfo>(m, "GrMockRenderTargetInfo")
+    .def(py::init<>())
+    .def(py::init<GrColorType, int>())
+    .def("__eq__", &GrMockRenderTargetInfo::operator==, py::is_operator())
+    .def("getBackendFormat", &GrMockRenderTargetInfo::getBackendFormat)
+    .def("colorType", &GrMockRenderTargetInfo::colorType)
+    ;
+
+py::class_<GrMockOptions>(m, "GrMockOptions")
+    .def(py::init<>())
+    // TODO: Implement me!
+    ;
+
+}

--- a/src/skia/GrContext_vk.cpp
+++ b/src/skia/GrContext_vk.cpp
@@ -1,0 +1,108 @@
+#include "common.h"
+#include <include/gpu/vk/GrVkBackendContext.h>
+
+void initGrContext_vk(py::module &m) {
+
+py::enum_<VkFormat>(m, "VkFormat", py::arithmetic())
+    .export_values();
+
+py::implicitly_convertible<int, VkFormat>();
+
+py::enum_<VkImageLayout>(m, "VkImageLayout", py::arithmetic())
+    .export_values();
+
+py::implicitly_convertible<int, VkImageLayout>();
+
+py::class_<GrVkAlloc>(m, "GrVkAlloc")
+    .def(py::init<>())
+    // TODO: Implement me!
+    ;
+
+py::class_<GrVkYcbcrConversionInfo>(m, "GrVkYcbcrConversionInfo")
+    .def(py::init<>())
+    // TODO: Implement me!
+    ;
+
+py::class_<GrVkImageInfo>(m, "GrVkImageInfo")
+    .def(py::init<>())
+    // .def(py::init(
+    //     [] (VkImage image,
+    //         GrVkAlloc alloc,
+    //         VkImageTiling imageTiling,
+    //         VkImageLayout layout,
+    //         VkFormat format,
+    //         uint32_t levelCount,
+    //         uint32_t currentQueueFamily,
+    //         GrProtected isProtected,
+    //         const GrVkYcbcrConversionInfo* ycbcrConversionInfo) {
+    //         return GrVkImageInfo(
+    //             image, alloc, imageTiling, layout, format, levelCount,
+    //             currentQueueFamily, isProtected,
+    //             (ycbcrConversionInfo) ?
+    //                 *ycbcrConversionInfo : GrVkYcbcrConversionInfo());
+    //     }),
+    //     py::arg("image"), py::arg("alloc"), py::arg("imageTiling"),
+    //     py::arg("layout"), py::arg("format"), py::arg("levelCount"),
+    //     py::arg("currentQueueFamily") = VK_QUEUE_FAMILY_IGNORED,
+    //     py::arg("isProtected") = GrProtected::kNo,
+    //     py::arg("ycbcrConversionInfo") = nullptr)
+    .def(py::init<const GrVkImageInfo&, VkImageLayout>(),
+        py::arg("info"), py::arg("layout"))
+    // .def_readwrite("fImage", &GrVkImageInfo::fImage)
+    .def_readwrite("fAlloc", &GrVkImageInfo::fAlloc)
+    // .def_readwrite("fImageTiling", &GrVkImageInfo::fImageTiling)
+    // .def_readwrite("fImageLayout", &GrVkImageInfo::fImageLayout)
+    // .def_readwrite("fFormat", &GrVkImageInfo::fFormat)
+    .def_readwrite("fLevelCount", &GrVkImageInfo::fLevelCount)
+    .def_readwrite("fCurrentQueueFamily", &GrVkImageInfo::fCurrentQueueFamily)
+    .def_readwrite("fProtected", &GrVkImageInfo::fProtected)
+    .def_readwrite("fYcbcrConversionInfo", &GrVkImageInfo::fYcbcrConversionInfo)
+    ;
+
+py::class_<GrVkDrawableInfo>(m, "GrVkDrawableInfo")
+    // TODO: Implement me!
+    ;
+
+// GrVkBackendContext.h
+py::enum_<GrVkExtensionFlags>(m, "GrVkExtensionFlags", py::arithmetic())
+    .value("kEXT_debug_report_GrVkExtensionFlag",
+        GrVkExtensionFlags::kEXT_debug_report_GrVkExtensionFlag)
+    .value("kNV_glsl_shader_GrVkExtensionFlag",
+        GrVkExtensionFlags::kNV_glsl_shader_GrVkExtensionFlag)
+    .value("kKHR_surface_GrVkExtensionFlag",
+        GrVkExtensionFlags::kKHR_surface_GrVkExtensionFlag)
+    .value("kKHR_swapchain_GrVkExtensionFlag",
+        GrVkExtensionFlags::kKHR_swapchain_GrVkExtensionFlag)
+    .value("kKHR_win32_surface_GrVkExtensionFlag",
+        GrVkExtensionFlags::kKHR_win32_surface_GrVkExtensionFlag)
+    .value("kKHR_android_surface_GrVkExtensionFlag",
+        GrVkExtensionFlags::kKHR_android_surface_GrVkExtensionFlag)
+    .value("kKHR_xcb_surface_GrVkExtensionFlag",
+        GrVkExtensionFlags::kKHR_xcb_surface_GrVkExtensionFlag)
+    .export_values();
+
+py::enum_<GrVkFeatureFlags>(m, "GrVkFeatureFlags", py::arithmetic())
+    .value("kGeometryShader_GrVkFeatureFlag",
+        GrVkFeatureFlags::kGeometryShader_GrVkFeatureFlag)
+    .value("kDualSrcBlend_GrVkFeatureFlag",
+        GrVkFeatureFlags::kDualSrcBlend_GrVkFeatureFlag)
+    .value("kSampleRateShading_GrVkFeatureFlag",
+        GrVkFeatureFlags::kSampleRateShading_GrVkFeatureFlag)
+    .export_values();
+
+py::class_<GrVkBackendContext>(m, "GrVkBackendContext",
+    R"docstring(
+    The BackendContext contains all of the base Vulkan objects needed by the
+    GrVkGpu. The assumption is that the client will set these up and pass them
+    to the GrVkGpu constructor. The VkDevice created must support at least one
+    graphics queue, which is passed in as well. The QueueFamilyIndex must match
+    the family of the given queue. It is needed for CommandPool creation, and
+    any GrBackendObjects handed to us (e.g., for wrapped textures) needs to be
+    created in or transitioned to that family. The refs held by members of this
+    struct must be released (either by deleting the struct or manually releasing
+    the refs) before the underlying vulkan device and instance are destroyed.
+    )docstring")
+    .def(py::init<>())
+    // TODO: Implement me!
+    ;
+}


### PR DESCRIPTION
- Split gl, vk, and mock implementation files
- Add missing GrBackendRenderTarget (Fix #85)
- Add `py::arithmetic()` to flags
- Add Vk API bindings without runtime testing