### PR TITLE
Upgrade skia to m86

### DIFF
--- a/docs/tutorial/paint.rst
+++ b/docs/tutorial/paint.rst
@@ -204,7 +204,7 @@ Bitmap Shader
 
 .. code-block:: python
 
-    image = skia.Image.DecodeToRaster(
+    image = skia.Image.MakeFromEncoded(
         skia.Data.MakeFromFileName('../skia/resources/images/color_wheel.png'))
 
     canvas.clear(skia.ColorWHITE)
@@ -397,7 +397,7 @@ Color Matrix Color Filter
 
 .. code-block:: python
 
-    image = skia.Image.DecodeToRaster(
+    image = skia.Image.MakeFromEncoded(
         skia.Data.MakeFromFileName(
             '../skia/resources/images/mandrill_512_q075.jpg'))
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '85.0'
+__version__ = '86.0'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if sys.platform == 'win32':
     EXTRA_COMPILE_ARGS = [
         '/std:c++17',  # c++20 fails.
         '/DVERSION_INFO=%s' % __version__,
+        '/DSK_GL',
         '/Zc:inline',
         # Disable a bunch of warnings.
         '/wd5030',  # Warnings about unknown attributes.
@@ -47,7 +48,10 @@ if sys.platform == 'win32':
         '/OPT:REF',
     ]
 elif sys.platform == 'darwin':
-    DEFINE_MACROS = [('VERSION_INFO', __version__)]
+    DEFINE_MACROS = [
+        ('VERSION_INFO', __version__),
+        ('SK_GL', ''),
+    ]
     LIBRARIES = [
         'dl',
     ]
@@ -67,7 +71,10 @@ elif sys.platform == 'darwin':
         '-framework', 'OpenGL',
     ]
 else:
-    DEFINE_MACROS = [('VERSION_INFO', __version__)]
+    DEFINE_MACROS = [
+        ('VERSION_INFO', __version__),
+        ('SK_GL', ''),
+    ]
     LIBRARIES = [
         'dl',
         'fontconfig',

--- a/src/skia/Bitmap.cpp
+++ b/src/skia/Bitmap.cpp
@@ -391,32 +391,6 @@ bitmap
         :return: true if :py:class:`ImageInfo` :py:class:`AlphaType` is
             :py:attr:`~AlphaType.kOpaque_AlphaType`
         )docstring")
-    .def("isVolatile", &SkBitmap::isVolatile,
-        R"docstring(
-        Provides a hint to caller that pixels should not be cached.
-
-        Only true if :py:meth:`setIsVolatile` has been called to mark as
-        volatile.
-
-        Volatile state is not shared by other bitmaps sharing the same
-        :py:class:`PixelRef`.
-
-        :return: true if marked volatile
-        )docstring")
-    .def("setIsVolatile", &SkBitmap::setIsVolatile,
-        R"docstring(
-        Sets if pixels should be read from :py:class:`PixelRef` on every access.
-
-        :py:class:`Bitmap` are not volatile by default; a GPU back end may
-        upload pixel values expecting them to be accessed repeatedly. Marking
-        temporary :py:class:`Bitmap` as volatile provides a hint to
-        :py:class:`BaseDevice` that the :py:class:`Bitmap` pixels should not be
-        cached. This can improve performance by avoiding overhead and reducing
-        resource consumption on :py:class:`BaseDevice`.
-
-        :param bool isVolatile: true if backing pixels are temporary
-        )docstring",
-        py::arg("isVolatile") = true)
     .def("reset", &SkBitmap::reset,
         R"docstring(
         Resets to its initial state; all fields are set to zero, as if

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -641,12 +641,6 @@ py::class_<SkFontMgr, sk_sp<SkFontMgr>, SkRefCnt>(m, "FontMgr",
         )docstring",
         py::arg("familyName"), py::arg("style"), py::arg("bcp47"),
         py::arg("character"))
-    .def("matchFaceStyle",
-        [] (const SkFontMgr& fontmgr, const SkTypeface* face,
-            const SkFontStyle& style) {
-            return sk_sp<SkTypeface>(fontmgr.matchFaceStyle(face, style));
-        },
-        py::arg("face"), py::arg("style"))
     .def("makeFromData", &SkFontMgr::makeFromData,
         R"docstring(
         Create a typeface for the specified data and TTC index (pass 0 for none)

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -275,7 +275,7 @@ py::class_<GrBackendTexture>(m, "GrBackendTexture")
     .def("dimensions", &GrBackendTexture::dimensions)
     .def("width", &GrBackendTexture::width)
     .def("height", &GrBackendTexture::height)
-    .def("hasMipMaps", &GrBackendTexture::hasMipMaps)
+    .def("hasMipmaps", &GrBackendTexture::hasMipmaps)
     .def("backend", &GrBackendTexture::backend)
     .def("getGLTextureInfo", &GrBackendTexture::getGLTextureInfo,
         py::arg("info"))
@@ -935,7 +935,7 @@ py::class_<GrContext, sk_sp<GrContext>, GrRecordingContext>(m, "GrContext")
         If the backend texture is mip mapped, the data for all the mipmap levels
         must be provided. In the mipmapped case all the colortypes of the
         provided pixmaps must be the same. Additionally, all the miplevels must
-        be sized correctly (please see SkMipMap::ComputeLevelSize and
+        be sized correctly (please see SkMipmap::ComputeLevelSize and
         ComputeLevelCount). Note: the pixmap's alphatypes and colorspaces are
         ignored. For the Vulkan backend after a successful update the layout of
         the created VkImage will be: VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -31,13 +31,13 @@ py::enum_<GrBackendApi>(m, "GrBackendApi",
         )docstring")
     .export_values();
 
-py::enum_<GrMipMapped>(m, "GrMipMapped",
+py::enum_<GrMipmapped>(m, "GrMipmapped",
     R"docstring(
     Used to say whether a texture has mip levels allocated or not.
     )docstring",
     py::arithmetic())
-    .value("kNo", GrMipMapped::kNo)
-    .value("kYes", GrMipMapped::kYes)
+    .value("kNo", GrMipmapped::kNo)
+    .value("kYes", GrMipmapped::kYes)
     .export_values();
 
 py::enum_<GrRenderable>(m, "GrRenderable", py::arithmetic())
@@ -97,14 +97,6 @@ py::enum_<GrGLBackendState>(m, "GrGLBackendState", R"docstring(
         GrGLBackendState::kALL_GrGLBackendState)
     .export_values();
 
-py::enum_<GrFlushFlags>(m, "GrFlushFlags", R"docstring(
-    Enum used as return value when flush with semaphores so the client knows
-    whether the semaphores were submitted to GPU or not.
-    )docstring", py::arithmetic())
-    .value("kNone_GrFlushFlags", GrFlushFlags::kNone_GrFlushFlags)
-    .value("kSyncCpu_GrFlushFlag", GrFlushFlags::kSyncCpu_GrFlushFlag)
-    .export_values();
-
 py::class_<GrFlushInfo>(m, "GrFlushInfo",
     R"docstring(
     Struct to supply options to flush calls.
@@ -147,7 +139,6 @@ py::class_<GrFlushInfo>(m, "GrFlushInfo",
     terms of how the submitted procs are treated.
     )docstring")
     .def(py::init<>())
-    .def_readwrite("fFlags", &GrFlushInfo::fFlags)
     .def_readonly("fNumSemaphores", &GrFlushInfo::fNumSemaphores)
     .def_property("semaphores",
         [] (const GrFlushInfo& info) -> py::object {
@@ -270,14 +261,14 @@ py::class_<GrBackendFormat>(m, "GrBackendFormat")
 
 py::class_<GrBackendTexture>(m, "GrBackendTexture")
     .def(py::init<>())
-    .def(py::init<int, int, GrMipMapped, const GrGLTextureInfo&>(),
+    .def(py::init<int, int, GrMipmapped, const GrGLTextureInfo&>(),
         py::arg("width"), py::arg("height"), py::arg("mipMapped"),
         py::arg("glInfo"))
 #ifdef SK_VULKAN
     .def(py::init<int, int, const GrVkImageInfo&>(),
         py::arg("width"), py::arg("height"), py::arg("vkInfo"))
 #endif
-    .def(py::init<int, int, GrMipMapped, const GrMockTextureInfo&>(),
+    .def(py::init<int, int, GrMipmapped, const GrMockTextureInfo&>(),
         py::arg("width"), py::arg("height"), py::arg("mipMapped"),
         py::arg("mockInfo"))
     .def(py::init<const GrBackendTexture&>(), py::arg("that"))
@@ -392,7 +383,83 @@ py::class_<GrBackendRenderTarget>(m, "GrBackendRenderTarget")
     .def("isValid", &GrBackendRenderTarget::isValid)
     ;
 
-py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
+py::class_<GrContext_Base, sk_sp<GrContext_Base>, SkRefCnt>(m, "GrContext_Base")
+    .def("asDirectContext", &GrContext_Base::asDirectContext,
+        R"docstring(
+        Safely downcast to a :py:class:`GrDirectContext`.
+        )docstring")
+    .def("backend", &GrContext_Base::backend,
+        R"docstring(
+        The 3D API backing this context.
+        )docstring")
+    .def("defaultBackendFormat", &GrContext_Base::defaultBackendFormat,
+        R"docstring(
+        Retrieve the default :py:class:`GrBackendFormat` for a given
+        :py:class:`ColorType` and renderability. It is guaranteed that this
+        backend format will be the one used by the :py:class:`GrContext`
+        :py:class:`ColorType` and SurfaceCharacterization-based
+        :py:meth:`createBackendTexture` methods.
+
+        The caller should check that the returned format is valid.
+        )docstring")
+    .def("compressedBackendFormat", &GrContext_Base::compressedBackendFormat)
+    .def("threadSafeProxy", &GrContext_Base::threadSafeProxy)
+    // .def("priv", py::overload_cast<>(&GrContext_Base::priv))
+    // .def("priv", py::overload_cast<>(&GrContext_Base::priv, py::const_))
+    ;
+
+py::class_<GrImageContext, sk_sp<GrImageContext>, GrContext_Base>(
+    m, "GrImageContext")
+    ;
+
+py::class_<GrRecordingContext, sk_sp<GrRecordingContext>, GrImageContext>(
+    m, "GrRecordingContext")
+    .def("defaultBackendFormat", &GrRecordingContext::defaultBackendFormat,
+        R"docstring(
+        Retrieve the default :py:class:`GrBackendFormat` for a given
+        :py:class:`ColorType` and renderability.
+
+        It is guaranteed that this backend format will be the one used by the
+        following :py:class:`ColorType` and SurfaceCharacterization-based
+        :py:meth:`createBackendTexture` methods.
+
+        The caller should check that the returned format is valid.
+        )docstring",
+        py::arg("colorType"), py::arg("renderable") = GrRenderable::kNo)
+    .def("abandoned", &GrRecordingContext::abandoned,
+        R"docstring(
+        Reports whether the :py:class:`GrDirectContext` associated with this
+        :py:class:`GrRecordingContext` is abandoned.
+
+        When called on a :py:class:`GrDirectContext` it may actively check
+        whether the underlying 3D API device/context has been disconnected
+        before reporting the status. If so, calling this method will transition
+        the :py:class:`GrDirectContext` to the abandoned state.
+        )docstring")
+    .def("colorTypeSupportedAsSurface",
+        &GrRecordingContext::colorTypeSupportedAsSurface,
+        R"docstring(
+        Can a :py:class:`Surface` be created with the given color type. To check
+        whether MSAA is supported use
+        :py:meth:`~GrRecordingContext.maxSurfaceSampleCountForColorType`.
+        )docstring",
+        py::arg("colorType"))
+    .def("maxSurfaceSampleCountForColorType",
+        &GrRecordingContext::maxSurfaceSampleCountForColorType,
+        R"docstring(
+        Gets the maximum supported sample count for a color type.
+
+        1 is returned if only non-MSAA rendering is supported for the color
+        type. 0 is returned if rendering to this color type is not supported at
+        all.
+        )docstring")
+    // .def("priv",
+    //     py::overload_cast<>(&GrRecordingContext::priv))
+    // .def("priv",
+    //     py::overload_cast<>(&GrRecordingContext::priv, py::const_))
+    ;
+
+py::class_<GrContext, sk_sp<GrContext>, GrRecordingContext>(m, "GrContext")
     .def("resetContext", &GrContext::resetContext,
         R"docstring(
         The :py:class:`GrContext` normally assumes that no outsider is setting
@@ -597,8 +664,10 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         py::arg("colorType"))
     .def("wait",
         [] (GrContext& context,
-            const std::vector<GrBackendSemaphore>& semaphores) {
-            return context.wait(semaphores.size(), &semaphores[0]);
+            const std::vector<GrBackendSemaphore>& semaphores,
+            bool deleteSemaphoresAfterWait) {
+            return context.wait(
+                semaphores.size(), &semaphores[0], deleteSemaphoresAfterWait);
         },
         R"docstring(
         Inserts a list of GPU semaphores that the current GPU-backed API must
@@ -609,7 +678,13 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         then the GPU back-end will not wait on any passed in semaphores, and the
         client will still own the semaphores.
         )docstring",
-        py::arg("semaphores"))
+        py::arg("semaphores"), py::arg("deleteSemaphoresAfterWait") = true)
+    .def("flushAndSubmit", &GrContext::flushAndSubmit,
+        R"docstring(
+        Call to ensure all drawing to the context has been flushed and submitted
+        to the underlying 3D API. This is equivalent to calling :py:meth:`flush`
+        with a default :py:class:`GrFlushInfo` followed by :py:meth:`submit`.
+        )docstring")
     .def("flush", py::overload_cast<const GrFlushInfo&>(&GrContext::flush),
         R"docstring(
         Call to ensure all drawing to the context has been flushed to underlying
@@ -646,15 +721,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         submitted.
         )docstring",
         py::arg("info"))
-    // .def("flush",
-    //     py::overload_cast<const GrFlushInfo&,
-    //     const GrPrepareForExternalIORequests>(&GrContext::flush))
-    .def("flushAndSubmit", &GrContext::flushAndSubmit,
-        R"docstring(
-        Call to ensure all drawing to the context has been flushed and submitted
-        to the underlying 3D API. This is equivalent to calling :py:meth:`flush`
-        with a default :py:class:`GrFlushInfo` followed by :py:meth:`submit`.
-        )docstring")
+    .def("flush", py::overload_cast<>(&GrContext::flush))
     .def("submit", &GrContext::submit,
         R"docstring(
         Submit outstanding work to the gpu from all previously un-submitted
@@ -686,6 +753,8 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     //     "traceMemoryDump.")
     .def("supportsDistanceFieldText", &GrContext::supportsDistanceFieldText)
     .def("storeVkPipelineCacheData", &GrContext::storeVkPipelineCacheData)
+    .def_static("ComputeImageSize", &GrContext::ComputeImageSize,
+        py::arg("image"), py::arg("mipMapped"), py::arg("useNextPow2") = false)
     .def("defaultBackendFormat", &GrContext::defaultBackendFormat,
         R"docstring(
         Retrieve the default :py:class:`GrBackendFormat` for a given
@@ -699,7 +768,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         )docstring",
         py::arg("colorType"), py::arg("renderable") = GrRenderable::kNo)
     .def("createBackendTexture",
-        py::overload_cast<int, int, const GrBackendFormat&, GrMipMapped,
+        py::overload_cast<int, int, const GrBackendFormat&, GrMipmapped,
             GrRenderable, GrProtected>(&GrContext::createBackendTexture),
         R"docstring(
         The explicitly allocated backend texture API allows clients to use Skia
@@ -725,7 +794,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         py::arg("mipMapped"), py::arg("renderable"),
         py::arg("isProtected") = GrProtected::kNo)
     .def("createBackendTexture",
-        py::overload_cast<int, int, SkColorType, GrMipMapped,
+        py::overload_cast<int, int, SkColorType, GrMipmapped,
             GrRenderable, GrProtected>(&GrContext::createBackendTexture),
         R"docstring(
         If possible, create an uninitialized backend texture.
@@ -753,7 +822,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createBackendTexture",
         [] (GrContext& context, int width, int height,
             const GrBackendFormat& backendFormat, const SkColor4f& color,
-            GrMipMapped mipMapped, GrRenderable renderable,
+            GrMipmapped mipMapped, GrRenderable renderable,
             GrProtected isProtected) {
             return context.createBackendTexture(
                 width, height, backendFormat, color, mipMapped, renderable,
@@ -772,7 +841,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createBackendTexture",
         [] (GrContext& context, int width, int height,
             SkColorType colorType, const SkColor4f& color,
-            GrMipMapped mipMapped, GrRenderable renderable,
+            GrMipmapped mipMapped, GrRenderable renderable,
             GrProtected isProtected) {
             return context.createBackendTexture(
                 width, height, colorType, color, mipMapped, renderable,
@@ -886,7 +955,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createCompressedBackendTexture",
         [] (GrContext& context, int width, int height,
             const GrBackendFormat& backendFormat, const SkColor4f& color,
-            GrMipMapped mipMapped, GrProtected isProtected) {
+            GrMipmapped mipMapped, GrProtected isProtected) {
             return context.createCompressedBackendTexture(
                 width, height, backendFormat, color, mipMapped, isProtected);
         },
@@ -904,7 +973,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createCompressedBackendTexture",
         [] (GrContext& context, int width, int height,
             SkImage::CompressionType type, const SkColor4f& color,
-            GrMipMapped mipMapped, GrProtected isProtected) {
+            GrMipmapped mipMapped, GrProtected isProtected) {
             return context.createCompressedBackendTexture(
                 width, height, type, color, mipMapped, isProtected);
         },
@@ -913,7 +982,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createCompressedBackendTexture",
         [] (GrContext& context, int width, int height,
             const GrBackendFormat& backendFormat, py::buffer b,
-            GrMipMapped mipMapped, GrProtected isProtected) {
+            GrMipmapped mipMapped, GrProtected isProtected) {
             auto info = b.request();
             size_t size = (info.ndim) ? info.strides[0] * info.shape[0] : 0;
             return context.createCompressedBackendTexture(
@@ -926,7 +995,7 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
     .def("createCompressedBackendTexture",
         [] (GrContext& context, int width, int height,
             SkImage::CompressionType type, py::buffer b,
-            GrMipMapped mipMapped, GrProtected isProtected) {
+            GrMipmapped mipMapped, GrProtected isProtected) {
             auto info = b.request();
             size_t size = (info.ndim) ? info.strides[0] * info.shape[0] : 0;
             return context.createCompressedBackendTexture(
@@ -967,37 +1036,99 @@ py::class_<GrContext, sk_sp<GrContext>, SkRefCnt>(m, "GrContext")
         py::arg("texture"))
     .def("precompileShader", &GrContext::precompileShader,
         py::arg("key"), py::arg("data"))
-    .def_static("ComputeImageSize", &GrContext::ComputeImageSize,
-        py::arg("image"), py::arg("mipMapped"), py::arg("useNextPow2") = false)
+    ;
+
+py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrContext>(
+    m, "GrDirectContext")
+#ifdef SK_GL
     .def_static("MakeGL",
         py::overload_cast<sk_sp<const GrGLInterface>, const GrContextOptions&>(
-            &GrContext::MakeGL),
+            &GrDirectContext::MakeGL),
+        R"docstring(
+        Creates a :py:class:`GrDirectContext` for a backend context. If no
+        GrGLInterface is provided then the result of GrGLMakeNativeInterface()
+        is used if it succeeds.
+        )docstring",
         py::arg("interface"), py::arg("options"))
     .def_static("MakeGL",
-        py::overload_cast<sk_sp<const GrGLInterface>>(&GrContext::MakeGL),
+        py::overload_cast<sk_sp<const GrGLInterface>>(&GrDirectContext::MakeGL),
         py::arg("interface"))
     .def_static("MakeGL",
-        py::overload_cast<const GrContextOptions&>(&GrContext::MakeGL),
+        py::overload_cast<const GrContextOptions&>(&GrDirectContext::MakeGL),
         py::arg("options"))
-    .def_static("MakeGL", py::overload_cast<>(&GrContext::MakeGL))
+    .def_static("MakeGL", py::overload_cast<>(&GrDirectContext::MakeGL))
+#endif
+
+#ifdef SK_VULKAN
     .def_static("MakeVulkan",
         py::overload_cast<const GrVkBackendContext&, const GrContextOptions&>(
-            &GrContext::MakeVulkan),
+            &GrDirectContext::MakeVulkan),
         R"docstring(
         The Vulkan context (VkQueue, VkDevice, VkInstance) must be kept alive
-        until the returned GrContext is first destroyed or abandoned.
+        until the returned GrDirectContext is destroyed. This also means that
+        any objects created with this GrDirectContext (e.g. Surfaces, Images,
+        etc.) must also be released as they may hold refs on the
+        GrDirectContext. Once all these objects and the GrDirectContext are
+        released, then it is safe to delete the vulkan objects.
         )docstring",
         py::arg("backendContext"), py::arg("options"))
     .def_static("MakeVulkan",
-        py::overload_cast<const GrVkBackendContext&>(&GrContext::MakeVulkan),
+        py::overload_cast<const GrVkBackendContext&>(
+            &GrDirectContext::MakeVulkan),
         py::arg("backendContext"))
+#endif
+
     .def_static("MakeMock",
         py::overload_cast<const GrMockOptions*, const GrContextOptions&>(
-            &GrContext::MakeMock),
+            &GrDirectContext::MakeMock),
         py::arg("mockOptions"), py::arg("options"))
     .def_static("MakeMock",
-        py::overload_cast<const GrMockOptions*>(&GrContext::MakeMock),
+        py::overload_cast<const GrMockOptions*>(&GrDirectContext::MakeMock),
         py::arg("mockOptions"))
+    .def("abandonContext", &GrDirectContext::abandonContext,
+        R"docstring(
+        Abandons all GPU resources and assumes the underlying backend 3D API
+        context is no longer usable.
+
+        Call this if you have lost the associated GPU context, and thus internal
+        texture, buffer, etc. references/IDs are now invalid. Calling this
+        ensures that the destructors of the :py:class:`GrContext` and any of its
+        created resource objects will not make backend 3D API calls. Content
+        rendered but not previously flushed may be lost. After this function is
+        called all subsequent calls on the GrContext will fail or be no-ops.
+
+        The typical use case for this function is that the underlying 3D context
+        was lost and further API calls may crash.
+
+        For Vulkan, even if the device becomes lost, the VkQueue, VkDevice, or
+        VkInstance used to create the GrContext must be alive before calling
+        abandonContext.
+        )docstring")
+    .def("releaseResourcesAndAbandonContext",
+        &GrDirectContext::releaseResourcesAndAbandonContext,
+        R"docstring(
+        This is similar to :py:meth:`abandonContext` however the underlying 3D
+        context is not yet lost and the :py:class:`GrContext` will cleanup all
+        allocated resources before returning.
+
+        After returning it will assume that the underlying context may no longer
+        be valid.
+
+        The typical use case for this function is that the client is going to
+        destroy the 3D context but can't guarantee that :py:class:`GrContext`
+        will be destroyed first (perhaps because it may be ref'ed elsewhere by
+        either the client or Skia objects).
+
+        For Vulkan, even if the device becomes lost, the VkQueue, VkDevice, or
+        VkInstance used to create the GrContext must be alive before calling
+        :py:meth:`releaseResourcesAndAbandonContext`.
+        )docstring")
+    .def("freeGpuResources", &GrDirectContext::freeGpuResources,
+        R"docstring(
+        Frees GPU created by the context.
+
+        Can be called to reduce GPU memory pressure.
+        )docstring")
     ;
 
 initGrContext_gl(m);

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1124,10 +1124,6 @@ image
         The subset parameter specifies a area within the decoded image to create
         the image from. If subset is null, then the entire image is returned.
 
-        This is similar to DecodeTo[Raster,Texture], but this method will
-        attempt to defer the actual decode, while the DecodeTo... method
-        explicitly decode and allocate the backend when the call is made.
-
         If the encoded format is not supported, or subset is outside of the
         bounds of the decoded image, nullptr is returned.
 
@@ -1137,57 +1133,6 @@ image
         :return: created :py:class:`Image`, or nullptr
         )docstring",
         py::arg("encoded"), py::arg("subset") = nullptr)
-    .def_static("DecodeToRaster",
-        [] (py::buffer data, const SkIRect* subset) {
-            auto buffer = data.request();
-            auto size = (buffer.ndim) ? buffer.shape[0] * buffer.strides[0] : 0;
-            return SkImage::DecodeToRaster(buffer.ptr, size, subset);
-        },
-        R"docstring(
-        Decode the data in encoded/length into a raster image.
-
-        The subset parameter specifies a area within the decoded image to create
-        the image from. If subset is null, then the entire image is returned.
-
-        This is similar to MakeFromEncoded, but this method will always decode
-        immediately, and allocate the memory for the pixels for the lifetime of
-        the returned image.
-
-        If the encoded format is not supported, or subset is outside of the
-        bounds of the decoded image, nullptr is returned.
-
-        :param Union[bytes,bytearray,memoryview] data: the encoded data
-        :param skia.IRect subset:  the bounds of the pixels within the decoded
-            image to return. may be null.
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("encoded"), py::arg("subset") = nullptr)
-    .def_static("DecodeToTexture",
-        [] (GrContext* context, py::buffer data, const SkIRect* subset) {
-            auto buffer = data.request();
-            auto size = (buffer.ndim) ? buffer.shape[0] * buffer.strides[0] : 0;
-            return SkImage::DecodeToTexture(context, buffer.ptr, size, subset);
-        },
-        R"docstring(
-        Decode the data in encoded/length into a texture-backed image.
-
-        The subset parameter specifies a area within the decoded image to create
-        the image from. If subset is null, then the entire image is returned.
-
-        This is similar to :py:meth:`MakeFromEncoded`, but this method will
-        always decode immediately, and allocate the texture for the pixels for
-        the lifetime of the returned image.
-
-        If the encoded format is not supported, or subset is outside of the
-        bounds of the decoded image, nullptr is returned.
-
-        :param skia.GrContext context: GPU context
-        :param Union[bytes,bytearray,memoryview] encoded: the encoded data
-        :param skia.IRect subset: the bounds of the pixels within the decoded
-            image to return. may be null.
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("encoded"), py::arg("subset") = nullptr)
     .def_static("MakeTextureFromCompressed",
         &SkImage::MakeTextureFromCompressed,
         R"docstring(

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<SkBitmap> ImageToBitmap(
     return bitmap;
 }
 
-sk_sp<SkImage> ImageOpen(py::object fp, const SkIRect* subset) {
+sk_sp<SkImage> ImageOpen(py::object fp) {
     sk_sp<SkData> data(nullptr);
     if (hasattr(fp, "seek") && hasattr(fp, "read")) {
         fp.attr("seek")(0);
@@ -72,7 +72,7 @@ sk_sp<SkImage> ImageOpen(py::object fp, const SkIRect* subset) {
             throw py::value_error(
                 py::str("File not found: {}").format(path));
     }
-    auto image = SkImage::MakeFromEncoded(data, subset);
+    auto image = SkImage::MakeFromEncoded(data);
     if (!image)
         throw std::runtime_error("Failed to decode an image");
     return image;
@@ -342,14 +342,12 @@ image
                 data = skia.Data.MakeWithCopy(fp.read())
             else:
                 data = skia.Data.MakeFromFileName(fp)
-            image = skia.Image.MakeFromEncoded(data, subset)
+            image = skia.Image.MakeFromEncoded(data)
 
         :param fp: file path or file-like object that has `seek` and `read`
             method. file must be opened in binary mode.
-        :param skia.IRect subset: the bounds of the pixels within the decoded
-            image to return. may be null.
         )docstring",
-        py::arg("fp"), py::arg("subset") = nullptr)
+        py::arg("fp"))
     .def("save", &ImageSave,
         R"docstring(
         Saves :py:attr:`Image` to file path or file-like object.
@@ -466,6 +464,327 @@ image
         })
 
     // C++ wrappers.
+    .def_static("MakeRasterCopy", &SkImage::MakeRasterCopy,
+        R"docstring(
+        Creates :py:class:`Image` from :py:class:`Pixmap` and copy of pixels.
+
+        Since pixels are copied, :py:class:`Pixmap` pixels may be modified or
+        deleted without affecting :py:class:`Image`.
+
+        :py:class:`Image` is returned if :py:class:`Pixmap` is valid. Valid
+        :py:class:`Pixmap` parameters include: dimensions are greater than zero;
+        each dimension fits in 29 bits; :py:class:`ColorType` and
+        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
+        :py:attr:`~ColorType.kUnknown_ColorType`; row bytes are large enough to
+        hold one row of pixels; pixel address is not nullptr.
+
+        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
+            bytes
+        :return: copy of :py:class:`Pixmap` pixels, or nullptr
+        )docstring",
+        py::arg("pixmap"))
+    .def_static("MakeRasterData",
+        [] (const SkImageInfo& imageInfo, py::buffer b, size_t dstRowBytes) {
+            auto info = b.request();
+            auto rowBytes = ValidateBufferToImageInfo(
+                imageInfo, info, dstRowBytes);
+            auto data = SkData::MakeWithoutCopy(
+                info.ptr, info.strides[0] * info.shape[0]);
+            return SkImage::MakeRasterData(imageInfo, data, rowBytes);
+        },
+        R"docstring(
+        Creates :py:class:`Image` from :py:class:`ImageInfo`, sharing pixels.
+
+        :py:class:`Image` is returned if :py:class:`ImageInfo` is valid. Valid
+        :py:class:`ImageInfo` parameters include: dimensions are greater than
+        zero; each dimension fits in 29 bits; :py:class:`ColorType` and
+        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
+        :py:attr:`~ColorType.kUnknown_ColorType`; rowBytes are large enough to
+        hold one row of pixels; pixels is not nullptr, and contains enough data
+        for :py:class:`Image`.
+
+        :param skia.ImageInfo info: contains width, height,
+            :py:class:`AlphaType`, :py:class:`ColorType`, :py:class:`ColorSpace`
+        :param Union[bytes,bytearray,memoryview] pixels: pixel storage
+        :param int rowBytes: size of pixel row or larger
+        :return: :py:class:`Image` sharing pixels, or nullptr
+        )docstring",
+        py::arg("info"), py::arg("pixels").none(false), py::arg("rowBytes"))
+    .def_static("MakeFromRaster",
+        [] (const SkPixmap& pixmap) {
+            return SkImage::MakeFromRaster(pixmap, nullptr, nullptr);
+        },
+        R"docstring(
+        Creates :py:class:`Image` from pixmap, sharing :py:class:`Pixmap`
+        pixels.
+
+        :py:class:`Image` is returned if pixmap is valid. Valid
+        :py:class:`Pixmap` parameters include: dimensions are greater than zero;
+        each dimension fits in 29 bits; :py:class:`ColorType` and
+        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
+        :py:attr:`kUnknown_ColorType`; row bytes are large enough to hold one
+        row of pixels; pixel address is not nullptr.
+
+        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
+            bytes
+        :return: :py:class:`Image` sharing pixmap
+        )docstring",
+        py::arg("pixmap").none(false))
+    .def_static("MakeFromBitmap", &SkImage::MakeFromBitmap,
+        R"docstring(
+        Creates :py:class:`Image` from bitmap, sharing or copying bitmap pixels.
+
+        If the bitmap is marked immutable, and its pixel memory is shareable, it
+        may be shared instead of copied.
+
+        :py:class:`Image` is returned if bitmap is valid. Valid
+        :py:class:`Bitmap` parameters include: dimensions are greater than zero;
+        each dimension fits in 29 bits; :py:class:`ColorType` and
+        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
+        :py:attr:`kUnknown_ColorType`; row bytes are large enough to hold one
+        row of pixels; pixel address is not nullptr.
+
+        :param skia.Bitmap bitmap: :py:class:`ImageInfo`, row bytes, and pixels
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("bitmap"))
+    // .def_static("MakeFromGenerator", &SkImage::MakeFromGenerator,
+    //     "Creates SkImage from data returned by imageGenerator.")
+    .def_static("MakeFromEncoded", &SkImage::MakeFromEncoded,
+        R"docstring(
+        Return an image backed by the encoded data, but attempt to defer
+        decoding until the image is actually used/drawn.
+
+        This deferral allows the system to cache the result, either on the CPU
+        or on the GPU, depending on where the image is drawn. If memory is low,
+        the cache may be purged, causing the next draw of the image to have to
+        re-decode.
+
+        If the encoded format is not supported, nullptr is returned.
+
+        :param encoded: the encoded data
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("encoded"))
+    .def_static("MakeTextureFromCompressed",
+        &SkImage::MakeTextureFromCompressed,
+        R"docstring(
+        Creates a GPU-backed :py:class:`Image` from compressed data.
+
+        This method will return an :py:class:`Image` representing the compressed
+        data. If the GPU doesn't support the specified compression method, the
+        data will be decompressed and then wrapped in a GPU-backed image.
+
+        Note: one can query the supported compression formats via
+        :py:meth:`GrContext.compressedBackendFormat`.
+
+        :param skia.GrDirectContext context: GPU context
+        :param skia.Data data: compressed data to store in :py:class:`Image`
+        :param int width: width of full :py:class:`Image`
+        :param int height: height of full :py:class:`Image`
+        :param skia.CompressionType type: type of compression used
+        :param skia.GrMipmapped mipMapped: does 'data' contain data for all the
+            mipmap levels?
+        :param skia.GrProtected isProtected: do the contents of 'data' require
+            DRM protection (on Vulkan)?
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("context"), py::arg("data"), py::arg("width"),
+        py::arg("height"), py::arg("type"),
+        py::arg("mipMapped") = GrMipmapped::kNo,
+        py::arg("isProtected") = GrProtected::kNo)
+    .def_static("MakeRasterFromCompressed", &SkImage::MakeRasterFromCompressed,
+        R"docstring(
+        Creates a CPU-backed :py:class:`Image` from compressed data.
+
+        This method will decompress the compressed data and create an image
+        wrapping it. Any mipmap levels present in the compressed data are
+        discarded.
+
+        :param skia.Data data: compressed data to store in SkImage
+        :param int width: width of full SkImage
+        :param int height: height of full SkImage
+        :param skia.Image.CompressionType type: type of compression used
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("data"), py::arg("width"), py::arg("height"), py::arg("type"))
+    .def_static("MakeFromTexture",
+        [] (GrRecordingContext* context, const GrBackendTexture& texture,
+            GrSurfaceOrigin origin, SkColorType colorType,
+            SkAlphaType alphaType, const SkColorSpace* cs) {
+            return SkImage::MakeFromTexture(
+                context, texture, origin, colorType, alphaType,
+                CloneColorSpace(cs));
+        },
+        R"docstring(
+        Creates :py:class:`Image` from GPU texture associated with context.
+
+        Caller is responsible for managing the lifetime of GPU texture.
+
+        :py:class:`Image` is returned if format of backendTexture is recognized
+        and supported. Recognized formats vary by GPU back-end.
+
+        :param skia.GrRecordingContext context: GPU context
+        :param skia.GrBackendTexture backendTexture: texture residing on GPU
+        :param skia.ColorSpace colorSpace: range of colors; may be nullptr
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("context"), py::arg("texture"), py::arg("origin"),
+        py::arg("colorType"), py::arg("alphaType"),
+        py::arg("colorSpace") = nullptr)
+    .def_static("MakeFromCompressedTexture",
+        [] (GrRecordingContext* context, const GrBackendTexture& texture,
+            GrSurfaceOrigin origin, SkAlphaType alphaType,
+            const SkColorSpace* cs) {
+            return SkImage::MakeFromCompressedTexture(
+                context, texture, origin, alphaType, CloneColorSpace(cs),
+                nullptr, nullptr);
+        },
+        R"docstring(
+        Creates an :py:class:`Image` from a GPU backend texture.
+
+        An :py:class:`Image` is returned if the format of backendTexture is
+        recognized and supported. Recognized formats vary by GPU back-end.
+
+        :param skia.GrRecordingContext context: the GPU context
+        :param skia.GrBackendTexture backendTexture: a texture already allocated
+            by the GPU
+        :param skia.AlphaType alphaType: This characterizes the nature of the
+            alpha values in the backend texture. For opaque compressed formats
+            (e.g., ETC1) this should usually be set to
+            :py:attr:`~AlphaType.kOpaque_AlphaType`.
+        :param skia.ColorSpace colorSpace: This describes the color space of
+            this image's contents, as seen after sampling. In general, if the
+            format of the backend texture is SRGB, some linear colorSpace should
+            be supplied (e.g., :py:meth:`ColorSpace.MakeSRGBLinear` ). If the
+            format of the backend texture is linear, then the colorSpace should
+            include a description of the transfer function as well (e.g.,
+            :py:meth:`ColorSpace.MakeSRGB` ).
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("context"), py::arg("texture"), py::arg("origin"),
+        py::arg("alphaType"), py::arg("colorSpace") = nullptr)
+    .def_static("MakeCrossContextFromPixmap",
+        &SkImage::MakeCrossContextFromPixmap,
+        R"docstring(
+        Creates :py:class:`Image` from pixmap.
+
+        :py:class:`Image` is uploaded to GPU back-end using context.
+
+        Created :py:class:`Image` is available to other GPU contexts, and is
+        available across thread boundaries. All contexts must be in the same GPU
+        share group, or otherwise share resources.
+
+        When :py:class:`Image` is no longer referenced, context releases texture
+        memory asynchronously.
+
+        :py:class:`GrBackendTexture` created from pixmap is uploaded to match
+        :py:class:`Surface` created with dstColorSpace. :py:class:`ColorSpace`
+        of :py:class:`Image` is determined by pixmap.colorSpace().
+
+        :py:class:`Image` is returned referring to GPU back-end if context is
+        not nullptr, format of data is recognized and supported, and if context
+        supports moving resources between contexts. Otherwise, pixmap pixel data
+        is copied and :py:class:`Image` as returned in raster format if
+        possible; nullptr may be returned. Recognized GPU formats vary by
+        platform and GPU back-end.
+
+        :param skia.GrDirectContext context: GPU context
+        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
+            bytes
+        :param bool buildMips: create :py:class:`Image` as mip map if true
+        :param bool limitToMaxTextureSize: downscale image to GPU maximum
+            texture size, if necessary
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("context"), py::arg("pixmap"), py::arg("buildMips"),
+        py::arg("limitToMaxTextureSize") = false)
+    .def_static("MakeFromAdoptedTexture",
+        [] (GrRecordingContext* context, const GrBackendTexture& backendTexture,
+            GrSurfaceOrigin origin, SkColorType colorType,
+            SkAlphaType alphaType, const SkColorSpace* colorSpace) {
+            return SkImage::MakeFromAdoptedTexture(
+                context, backendTexture, origin, colorType, alphaType,
+                CloneColorSpace(colorSpace));
+        },
+        R"docstring(
+        Creates :py:class:`Image` from backendTexture associated with context.
+
+        backendTexture and returned :py:class:`Image` are managed internally,
+        and are released when no longer needed.
+
+        :py:class:`Image` is returned if format of backendTexture is recognized
+        and supported. Recognized formats vary by GPU back-end.
+
+        :param skia.GrContext context: GPU context
+        :param skia.GrBackendTexture backendTexture: texture residing on GPU
+        :param skia.ColorSpace colorSpace: range of colors; may be nullptr
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("context"), py::arg("backendTexture"), py::arg("origin"),
+        py::arg("colorType"),
+        py::arg("alphaType") = SkAlphaType::kPremul_SkAlphaType,
+        py::arg("colorSpace") = nullptr)
+    /*
+    .def_static("MakeFromYUVATexturesCopy", &SkImage::MakeFromYUVATexturesCopy,
+        "Creates an SkImage by flattening the specified YUVA planes into a "
+        "single, interleaved RGBA image.")
+    .def_static("MakeFromYUVATexturesCopyWithExternalBackend",
+        &SkImage::MakeFromYUVATexturesCopyWithExternalBackend,
+        "Creates an SkImage by flattening the specified YUVA planes into a "
+        "single, interleaved RGBA image.")
+    .def_static("MakeFromYUVATextures", &SkImage::MakeFromYUVATextures,
+        "Creates an SkImage by storing the specified YUVA planes into an image,"
+        " to be rendered via multitexturing.")
+    .def_static("MakeFromYUVAPixmaps", &SkImage::MakeFromYUVAPixmaps,
+        "Creates SkImage from pixmap array representing YUVA data.")
+    .def_static("MakeFromYUVTexturesCopy", &SkImage::MakeFromYUVTexturesCopy,
+        "To be deprecated.")
+    .def_static("MakeFromYUVTexturesCopyWithExternalBackend",
+        &SkImage::MakeFromYUVTexturesCopyWithExternalBackend,
+        "To be deprecated.")
+    .def_static("MakeFromNV12TexturesCopy", &SkImage::MakeFromNV12TexturesCopy,
+        "Creates SkImage from copy of nv12Textures, an array of textures on "
+        "GPU.")
+    .def_static("MakeFromNV12TexturesCopyWithExternalBackend",
+        &SkImage::MakeFromNV12TexturesCopyWithExternalBackend,
+        "Creates SkImage from copy of nv12Textures, an array of textures on "
+        "GPU.")
+    */
+    .def_static("MakeFromPicture",
+        [] (sk_sp<SkPicture>& picture, const SkISize& dimensions,
+            const SkMatrix* matrix, const SkPaint* paint,
+            SkImage::BitDepth bitDepth, const SkColorSpace* colorSpace) {
+            return SkImage::MakeFromPicture(
+                picture, dimensions, matrix, paint, bitDepth,
+                CloneColorSpace(colorSpace));
+        },
+        R"docstring(
+        Creates :py:class:`Image` from picture.
+
+        Returned :py:class:`Image` width and height are set by dimensions.
+        :py:class:`Image` draws picture with matrix and paint, set to bitDepth
+        and colorSpace.
+
+        If matrix is nullptr, draws with identity :py:class:`Matrix`. If paint
+        is nullptr, draws with default :py:class:`Paint`. colorSpace may be
+        nullptr.
+
+        :param skia.Picture picture: stream of drawing commands
+        :param skia.ISize dimensions:  width and height
+        :param skia.Matrix matrix: :py:class:`Matrix` to rotate, scale,
+            translate, and so on; may be nullptr
+        :param skia.Paint paint: :py:class:`Paint` to apply transparency,
+            filtering, and so on; may be nullptr
+        :param skia.Image.BitDepth bitDepth:    8-bit integer or 16-bit float:
+            per component
+        :param skia.ColorSpace colorSpace:  range of colors; may be nullptr
+        :return: created :py:class:`Image`, or nullptr
+        )docstring",
+        py::arg("picture"), py::arg("dimensions"), py::arg("matrix") = nullptr,
+        py::arg("paint") = nullptr,
+        py::arg("bitDepth") = SkImage::BitDepth::kU8,
+        py::arg("colorSpace") = nullptr)
     .def("imageInfo", &SkImage::imageInfo,
         R"docstring(
         Returns a :py:class:`ImageInfo` describing the width, height, color
@@ -595,6 +914,7 @@ image
         )docstring",
         py::arg("tmx") = SkTileMode::kClamp,
         py::arg("tmy") = SkTileMode::kClamp, py::arg("localMatrix") = nullptr)
+    // TODO: Other makeShader overloads.
     .def("peekPixels", &SkImage::peekPixels,
         R"docstring(
         Copies :py:class:`Image` pixel address, row bytes, and
@@ -626,29 +946,56 @@ image
         associated with context.
 
         :py:class:`Image` backed by GPU texture may become invalid if associated
-        GrContext is invalid. lazy image may be invalid and may not draw to
-        raster surface or GPU surface or both.
+        GrRecordingContext is invalid. lazy image may be invalid and may not draw
+        to raster surface or GPU surface or both.
 
-        :param skia.GrContext context: GPU context
+        :param skia.GrRecordingContext context: GPU context
         :return: true if :py:class:`Image` can be drawn
         )docstring",
         py::arg("context") = nullptr)
-    // .def("flush",
-    //     py::overload_cast<GrContext*, const GrFlushInfo&>(&SkImage::flush),
-    //     "Flushes any pending uses of texture-backed images in the GPU "
-    //     "backend.")
     .def("flush",
-        py::overload_cast<GrContext*>(&SkImage::flush),
+        py::overload_cast<GrDirectContext*, const GrFlushInfo&>(&SkImage::flush),
         R"docstring(
-        Flushes any pending uses of texture-backed images in the GPU backend.
+        Flushes any pending uses of texture-backed images in the GPU backend. If
+        the image is not texture-backed (including promise texture images) or if
+        the GrDirectContext does not have the same context ID as the context
+        backing the image then this is a no-op.
 
-        Uses a default GrFlushInfo.
+        If the image was not used in any non-culled draws in the current queue
+        of work for the passed GrDirectContext then this is a no-op unless the
+        GrFlushInfo contains semaphores or a finish proc. Those are respected
+        even when the image has not been used.
 
-        :param skia.GrContext context: GPU context
+        :param context:  the context on which to flush pending usages of the
+            image.
+        :param info:     flush options
+        )docstring"
+        )
+    .def("flush",
+        py::overload_cast<GrDirectContext*>(&SkImage::flush),
+        py::arg("context").none(false))
+    .def("flushAndSubmit", &SkImage::flushAndSubmit,
+        R"docstring(
+        Version of :py:meth:`flush` that uses a default GrFlushInfo.
+
+        Also submits the flushed work to the GPU.
         )docstring",
         py::arg("context").none(false))
-    // .def("getBackendTexture", &SkImage::getBackendTexture,
-    //     "Retrieves the back-end texture.")
+    .def("getBackendTexture", &SkImage::getBackendTexture,
+        R"docstring(
+        Retrieves the back-end texture. If :py:class:`Image` has no back-end
+        texture, an invalid object is returned. Call
+        :py:meth:`GrBackendTexture.isValid` to determine if the result is valid.
+
+        If flushPendingGrContextIO is true, completes deferred I/O operations.
+
+        If origin in not nullptr, copies location of content drawn into
+        :py:class:`Image`.
+
+        :param flushPendingGrContextIO: flag to flush outstanding requests
+        :return: back-end API texture handle; invalid on failure
+        )docstring",
+        py::arg("flushPendingGrContextIO"), py::arg("origin") = nullptr)
     .def("readPixels", &ImageReadPixels,
         R"docstring(
         Copies :py:class:`Rect` of pixels from :py:class:`Image` to array.
@@ -732,6 +1079,9 @@ image
         )docstring",
         py::arg("dst"), py::arg("srcX"), py::arg("srcY"),
         py::arg("cachingHint") = SkImage::CachingHint::kAllow_CachingHint)
+    // .def("asyncRescaleAndReadPixels", &SkImage::asyncRescaleAndReadPixels)
+    // .def("asyncRescaleAndReadPixelsYUV420",
+    //      &SkImage::asyncRescaleAndReadPixelsYUV420)
     .def("scalePixels", &SkImage::scalePixels,
         R"docstring(
         Copies :py:class:`Image` to dst, scaling pixels to fit ``dst.width()``
@@ -848,14 +1198,28 @@ image
         :param skia.IRect subset: bounds of returned :py:class:`Image`
         :return: partial or full :py:class:`Image`, or nullptr
         )docstring",
-        py::arg("subset"))
+        py::arg("subset"), py::arg("direct") = nullptr)
+    .def("hasMipmaps", &SkImage::hasMipmaps,
+        R"docstring(
+        Returns true if the image has mipmap levels.
+        )docstring")
+    // .def("withMipmaps", &SkImage::withMipmaps,
+    //     R"docstring(
+    //     Returns an image with the same "base" pixels as the this image, but with
+    //     mipmap levels as well. If this image already has mipmap levels, they
+    //     will be replaced with new ones.
+
+    //     If data == nullptr, the mipmap levels are computed automatically.
+    //     If data != nullptr, then the caller has provided the data for each
+    //     level.
+    //     )docstring")
     .def("makeTextureImage", &SkImage::makeTextureImage,
         R"docstring(
         Returns :py:class:`Image` backed by GPU texture associated with context.
 
         Returned :py:class:`Image` is compatible with :py:class:`Surface`
         created with dstColorSpace. The returned :py:class:`Image` respects
-        mipMapped setting; if mipMapped equals :py:attr:`GrMipMapped.kYes`, the
+        mipMapped setting; if mipMapped equals :py:attr:`GrMipmapped.kYes`, the
         backing texture allocates mip map levels.
 
         The mipMapped parameter is effectively treated as kNo if MIP maps are
@@ -866,16 +1230,17 @@ image
         the backing GPU texture. :py:class:`Budgeted` is ignored in this case.
 
         Returns nullptr if context is nullptr, or if :py:class:`Image` was
-        created with another GrContext.
+        created with another GrDirectContext.
 
-        :param GrContext context: GPU context
-        :param GrMipMapped mipMapped: whether created :py:class:`Image` texture
+        :param GrDirectContext context: the GrDirectContext in play, if it
+            exists
+        :param GrMipmapped mipMapped: whether created :py:class:`Image` texture
             must allocate mip map levels
         :param skia.Budgeted budgeted: whether to count a newly created texture
-            for the returned image counts against the GrContext's budget.
+            for the returned image counts against the GrDirectContext's budget.
         :return: created :py:class:`Image`, or nullptr
         )docstring",
-        py::arg("context").none(false), py::arg("mipMapped") = GrMipMapped::kNo,
+        py::arg("context").none(false), py::arg("mipMapped") = GrMipmapped::kNo,
         py::arg("budgeted") = SkBudgeted::kYes)
     .def("makeNonTextureImage", &SkImage::makeNonTextureImage,
         R"docstring(
@@ -909,7 +1274,7 @@ image
         )docstring",
         py::arg("cachingHint") = SkImage::kAllow_CachingHint)
     .def("makeWithFilter",
-        py::overload_cast<GrContext*, const SkImageFilter*,
+        py::overload_cast<GrRecordingContext*, const SkImageFilter*,
             const SkIRect&, const SkIRect&, SkIRect*, SkIPoint*>(
                 &SkImage::makeWithFilter, py::const_),
         R"docstring(
@@ -932,7 +1297,8 @@ image
         returned. offset translates the returned :py:class:`Image` to keep
         subsequent animation frames aligned with respect to each other.
 
-        :param skia.GrContext context: the GrContext in play - if it exists
+        :param skia.GrRecordingContext context: the GrRecordingContext in play -
+            if it exists
         :param skia.ImageFilter filter: how :py:class:`Image` is sampled when
             transformed
         :param skia.IRect subset:  bounds of :py:class:`Image` processed by
@@ -948,414 +1314,8 @@ image
         py::arg("context"), py::arg("filter"), py::arg("subset"),
         py::arg("clipBounds"), py::arg("outSubset").none(false),
         py::arg("offset").none(false))
-    .def("asLegacyBitmap", &SkImage::asLegacyBitmap,
-        R"docstring(
-        Deprecated.
-
-        Creates raster :py:class:`Bitmap` with same pixels as :py:class:`Image`.
-        If legacyBitmapMode is :py:attr:`~Image.kRO_LegacyBitmapMode`, returned
-        bitmap is read-only and immutable. Returns true if :py:class:`Bitmap` is
-        stored in bitmap. Returns false and resets bitmap if :py:class:`Bitmap`
-        write did not succeed.
-
-        :param bitmap: storage for legacy :py:class:`Bitmap`
-        :param legacyBitmapMode: bitmap is read-only and immutable
-        :return: true if :py:class:`Bitmap` was created
-        )docstring",
-        py::arg("bitmap").none(false),
-        py::arg("legacyBitmapMode") = SkImage::kRO_LegacyBitmapMode)
-    .def("isLazyGenerated", &SkImage::isLazyGenerated,
-        R"docstring(
-        Returns true if :py:class:`Image` is backed by an image-generator or
-        other service that creates and caches its pixels or texture on-demand.
-
-        :return: true if :py:class:`Image` is created as needed
-        )docstring")
-    .def("makeColorSpace",
-        [] (const SkImage& image, const SkColorSpace* target) {
-            return image.makeColorSpace(CloneColorSpace(target));
-        },
-        R"docstring(
-        Creates :py:class:`Image` in target :py:class:`ColorSpace`.
-
-        Returns nullptr if :py:class:`Image` could not be created.
-
-        Returns original :py:class:`Image` if it is in target
-        :py:class:`ColorSpace`. Otherwise, converts pixels from
-        :py:class:`Image` :py:class:`ColorSpace` to target
-        :py:class:`ColorSpace`. If :py:class:`Image` colorSpace() returns
-        nullptr, :py:class:`Image` :py:class:`ColorSpace` is assumed to be sRGB.
-
-        :param skia.ColorSpace target: :py:class:`ColorSpace` describing color
-            range of returned :py:class:`Image`
-        :return: created :py:class:`Image` in target :py:class:`ColorSpace`
-        )docstring",
-        py::arg("target"))
-    .def("makeColorTypeAndColorSpace",
-        [] (const SkImage& image, SkColorType ct, const SkColorSpace* cs) {
-            return image.makeColorTypeAndColorSpace(ct, CloneColorSpace(cs));
-        },
-        R"docstring(
-        Experimental.
-
-        Creates :py:class:`Image` in target :py:class:`ColorType` and
-        :py:class:`ColorSpace`. Returns nullptr if :py:class:`Image` could not
-        be created.
-
-        Returns original :py:class:`Image` if it is in target
-        :py:class:`ColorType` and :py:class:`ColorSpace`.
-
-        :param skia.ColorType targetColorType: :py:class:`ColorType` of returned
-            :py:class:`Image`
-        :param skia.ColorSpace targetColorSpace: :py:class:`ColorSpace` of
-            returned :py:class:`Image`
-        :return: created :py:class:`Image` in target :py:class:`ColorType` and
-            :py:class:`ColorSpace`
-        )docstring",
-        py::arg("targetColorType"), py::arg("targetColorSpace") = nullptr)
-    .def("reinterpretColorSpace",
-        [] (const SkImage& image, const SkColorSpace* cs) {
-            return image.reinterpretColorSpace(CloneColorSpace(cs));
-        },
-        R"docstring(
-        Creates a new :py:class:`Image` identical to this one, but with a
-        different :py:class:`ColorSpace`.
-
-        This does not convert the underlying pixel data, so the resulting image
-        will draw differently.
-        )docstring",
-        py::arg("newColorSpace") = nullptr)
-    .def_static("MakeRasterCopy", &SkImage::MakeRasterCopy,
-        R"docstring(
-        Creates :py:class:`Image` from :py:class:`Pixmap` and copy of pixels.
-
-        Since pixels are copied, :py:class:`Pixmap` pixels may be modified or
-        deleted without affecting :py:class:`Image`.
-
-        :py:class:`Image` is returned if :py:class:`Pixmap` is valid. Valid
-        :py:class:`Pixmap` parameters include: dimensions are greater than zero;
-        each dimension fits in 29 bits; :py:class:`ColorType` and
-        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
-        :py:attr:`~ColorType.kUnknown_ColorType`; row bytes are large enough to
-        hold one row of pixels; pixel address is not nullptr.
-
-        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
-            bytes
-        :return: copy of :py:class:`Pixmap` pixels, or nullptr
-        )docstring",
-        py::arg("pixmap"))
-    .def_static("MakeRasterData",
-        [] (const SkImageInfo& imageInfo, py::buffer b, size_t dstRowBytes) {
-            auto info = b.request();
-            auto rowBytes = ValidateBufferToImageInfo(
-                imageInfo, info, dstRowBytes);
-            auto data = SkData::MakeWithoutCopy(
-                info.ptr, info.strides[0] * info.shape[0]);
-            return SkImage::MakeRasterData(imageInfo, data, rowBytes);
-        },
-        R"docstring(
-        Creates :py:class:`Image` from :py:class:`ImageInfo`, sharing pixels.
-
-        :py:class:`Image` is returned if :py:class:`ImageInfo` is valid. Valid
-        :py:class:`ImageInfo` parameters include: dimensions are greater than
-        zero; each dimension fits in 29 bits; :py:class:`ColorType` and
-        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
-        :py:attr:`~ColorType.kUnknown_ColorType`; rowBytes are large enough to
-        hold one row of pixels; pixels is not nullptr, and contains enough data
-        for :py:class:`Image`.
-
-        :param skia.ImageInfo info: contains width, height,
-            :py:class:`AlphaType`, :py:class:`ColorType`, :py:class:`ColorSpace`
-        :param Union[bytes,bytearray,memoryview] pixels: pixel storage
-        :param int rowBytes: size of pixel row or larger
-        :return: :py:class:`Image` sharing pixels, or nullptr
-        )docstring",
-        py::arg("info"), py::arg("pixels").none(false), py::arg("rowBytes"))
-    .def_static("MakeFromRaster",
-        [] (const SkPixmap& pixmap) {
-            return SkImage::MakeFromRaster(pixmap, nullptr, nullptr);
-        },
-        R"docstring(
-        Creates :py:class:`Image` from pixmap, sharing :py:class:`Pixmap`
-        pixels.
-
-        :py:class:`Image` is returned if pixmap is valid. Valid
-        :py:class:`Pixmap` parameters include: dimensions are greater than zero;
-        each dimension fits in 29 bits; :py:class:`ColorType` and
-        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
-        :py:attr:`kUnknown_ColorType`; row bytes are large enough to hold one
-        row of pixels; pixel address is not nullptr.
-
-        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
-            bytes
-        :return: :py:class:`Image` sharing pixmap
-        )docstring",
-        py::arg("pixmap").none(false))
-    .def_static("MakeFromBitmap", &SkImage::MakeFromBitmap,
-        R"docstring(
-        Creates :py:class:`Image` from bitmap, sharing or copying bitmap pixels.
-
-        If the bitmap is marked immutable, and its pixel memory is shareable, it
-        may be shared instead of copied.
-
-        :py:class:`Image` is returned if bitmap is valid. Valid
-        :py:class:`Bitmap` parameters include: dimensions are greater than zero;
-        each dimension fits in 29 bits; :py:class:`ColorType` and
-        :py:class:`AlphaType` are valid, and :py:class:`ColorType` is not
-        :py:attr:`kUnknown_ColorType`; row bytes are large enough to hold one
-        row of pixels; pixel address is not nullptr.
-
-        :param skia.Bitmap bitmap: :py:class:`ImageInfo`, row bytes, and pixels
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("bitmap"))
-    // .def_static("MakeFromGenerator", &SkImage::MakeFromGenerator,
-    //     "Creates SkImage from data returned by imageGenerator.")
-    .def_static("MakeFromEncoded", &SkImage::MakeFromEncoded,
-        R"docstring(
-        Return an image backed by the encoded data, but attempt to defer
-        decoding until the image is actually used/drawn.
-
-        This deferral allows the system to cache the result, either on the CPU
-        or on the GPU, depending on where the image is drawn. If memory is low,
-        the cache may be purged, causing the next draw of the image to have to
-        re-decode.
-
-        The subset parameter specifies a area within the decoded image to create
-        the image from. If subset is null, then the entire image is returned.
-
-        If the encoded format is not supported, or subset is outside of the
-        bounds of the decoded image, nullptr is returned.
-
-        :param encoded: the encoded data
-        :param skia.IRect subset:  the bounds of the pixels within the decoded
-            image to return. may be null.
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("encoded"), py::arg("subset") = nullptr)
-    .def_static("MakeTextureFromCompressed",
-        &SkImage::MakeTextureFromCompressed,
-        R"docstring(
-        Creates a GPU-backed :py:class:`Image` from compressed data.
-
-        This method will return an :py:class:`Image` representing the compressed
-        data. If the GPU doesn't support the specified compression method, the
-        data will be decompressed and then wrapped in a GPU-backed image.
-
-        Note: one can query the supported compression formats via
-        :py:meth:`GrContext.compressedBackendFormat`.
-
-        :param skia.GrContext context: GPU context
-        :param skia.Data data: compressed data to store in :py:class:`Image`
-        :param int width: width of full :py:class:`Image`
-        :param int height: height of full :py:class:`Image`
-        :param skia.CompressionType type: type of compression used
-        :param skia.GrMipMapped mipMapped: does 'data' contain data for all the
-            mipmap levels?
-        :param skia.GrProtected isProtected: do the contents of 'data' require
-            DRM protection (on Vulkan)?
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("data"), py::arg("width"),
-        py::arg("height"), py::arg("type"),
-        py::arg("mipMapped") = GrMipMapped::kNo,
-        py::arg("isProtected") = GrProtected::kNo)
-    // .def_static("MakeFromCompressed", &SkImage::MakeFromCompressed,
-    //     "To be deprecated.")
-    .def_static("MakeRasterFromCompressed", &SkImage::MakeRasterFromCompressed,
-        R"docstring(
-        Creates a CPU-backed :py:class:`Image` from compressed data.
-
-        This method will decompress the compressed data and create an image
-        wrapping it. Any mipmap levels present in the compressed data are
-        discarded.
-
-        :param skia.Data data: compressed data to store in SkImage
-        :param int width: width of full SkImage
-        :param int height: height of full SkImage
-        :param skia.Image.CompressionType type: type of compression used
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("data"), py::arg("width"), py::arg("height"), py::arg("type"))
-    .def_static("MakeFromTexture",
-        [] (GrContext* context, const GrBackendTexture& texture,
-            GrSurfaceOrigin origin, SkColorType colorType,
-            SkAlphaType alphaType, const SkColorSpace* cs) {
-            return SkImage::MakeFromTexture(
-                context, texture, origin, colorType, alphaType,
-                CloneColorSpace(cs));
-        },
-        R"docstring(
-        Creates :py:class:`Image` from GPU texture associated with context.
-
-        Caller is responsible for managing the lifetime of GPU texture.
-
-        :py:class:`Image` is returned if format of backendTexture is recognized
-        and supported. Recognized formats vary by GPU back-end.
-
-        :param skia.GrContext context: GPU context
-        :param skia.GrBackendTexture backendTexture: texture residing on GPU
-        :param skia.ColorSpace colorSpace: range of colors; may be nullptr
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("texture"), py::arg("origin"),
-        py::arg("colorType"), py::arg("alphaType"),
-        py::arg("colorSpace") = nullptr)
-    .def_static("MakeFromCompressedTexture",
-        [] (GrContext* context, const GrBackendTexture& texture,
-            GrSurfaceOrigin origin, SkAlphaType alphaType,
-            const SkColorSpace* cs) {
-            return SkImage::MakeFromCompressedTexture(
-                context, texture, origin, alphaType, CloneColorSpace(cs),
-                nullptr, nullptr);
-        },
-        R"docstring(
-        Creates an :py:class:`Image` from a GPU backend texture.
-
-        An :py:class:`Image` is returned if the format of backendTexture is
-        recognized and supported. Recognized formats vary by GPU back-end.
-
-        :param skia.GrContext context: the GPU context
-        :param skia.GrBackendTexture backendTexture: a texture already allocated
-            by the GPU
-        :param skia.AlphaType alphaType: This characterizes the nature of the
-            alpha values in the backend texture. For opaque compressed formats
-            (e.g., ETC1) this should usually be set to
-            :py:attr:`~AlphaType.kOpaque_AlphaType`.
-        :param skia.ColorSpace colorSpace: This describes the color space of
-            this image's contents, as seen after sampling. In general, if the
-            format of the backend texture is SRGB, some linear colorSpace should
-            be supplied (e.g., :py:meth:`ColorSpace.MakeSRGBLinear` ). If the
-            format of the backend texture is linear, then the colorSpace should
-            include a description of the transfer function as well (e.g.,
-            :py:meth:`ColorSpace.MakeSRGB` ).
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("texture"), py::arg("origin"),
-        py::arg("alphaType"), py::arg("colorSpace") = nullptr)
-    .def_static("MakeCrossContextFromPixmap",
-        &SkImage::MakeCrossContextFromPixmap,
-        R"docstring(
-        Creates :py:class:`Image` from pixmap.
-
-        :py:class:`Image` is uploaded to GPU back-end using context.
-
-        Created :py:class:`Image` is available to other GPU contexts, and is
-        available across thread boundaries. All contexts must be in the same GPU
-        share group, or otherwise share resources.
-
-        When :py:class:`Image` is no longer referenced, context releases texture
-        memory asynchronously.
-
-        :py:class:`GrBackendTexture` created from pixmap is uploaded to match
-        :py:class:`Surface` created with dstColorSpace. :py:class:`ColorSpace`
-        of :py:class:`Image` is determined by pixmap.colorSpace().
-
-        :py:class:`Image` is returned referring to GPU back-end if context is
-        not nullptr, format of data is recognized and supported, and if context
-        supports moving resources between contexts. Otherwise, pixmap pixel data
-        is copied and :py:class:`Image` as returned in raster format if
-        possible; nullptr may be returned. Recognized GPU formats vary by
-        platform and GPU back-end.
-
-        :param skia.GrContext context: GPU context
-        :param skia.Pixmap pixmap: :py:class:`ImageInfo`, pixel address, and row
-            bytes
-        :param bool buildMips: create :py:class:`Image` as mip map if true
-        :param bool limitToMaxTextureSize: downscale image to GPU maximum
-            texture size, if necessary
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("pixmap"), py::arg("buildMips"),
-        py::arg("limitToMaxTextureSize") = false)
-    .def_static("MakeFromAdoptedTexture",
-        [] (GrContext* context, const GrBackendTexture& backendTexture,
-            GrSurfaceOrigin origin, SkColorType colorType,
-            SkAlphaType alphaType, const SkColorSpace* colorSpace) {
-            return SkImage::MakeFromAdoptedTexture(
-                context, backendTexture, origin, colorType, alphaType,
-                CloneColorSpace(colorSpace));
-        },
-        R"docstring(
-        Creates :py:class:`Image` from backendTexture associated with context.
-
-        backendTexture and returned :py:class:`Image` are managed internally,
-        and are released when no longer needed.
-
-        :py:class:`Image` is returned if format of backendTexture is recognized
-        and supported. Recognized formats vary by GPU back-end.
-
-        :param skia.GrContext context: GPU context
-        :param skia.GrBackendTexture backendTexture: texture residing on GPU
-        :param skia.ColorSpace colorSpace: range of colors; may be nullptr
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("context"), py::arg("backendTexture"), py::arg("origin"),
-        py::arg("colorType"),
-        py::arg("alphaType") = SkAlphaType::kPremul_SkAlphaType,
-        py::arg("colorSpace") = nullptr)
-    /*
-    .def_static("MakeFromYUVATexturesCopy", &SkImage::MakeFromYUVATexturesCopy,
-        "Creates an SkImage by flattening the specified YUVA planes into a "
-        "single, interleaved RGBA image.")
-    .def_static("MakeFromYUVATexturesCopyWithExternalBackend",
-        &SkImage::MakeFromYUVATexturesCopyWithExternalBackend,
-        "Creates an SkImage by flattening the specified YUVA planes into a "
-        "single, interleaved RGBA image.")
-    .def_static("MakeFromYUVATextures", &SkImage::MakeFromYUVATextures,
-        "Creates an SkImage by storing the specified YUVA planes into an image,"
-        " to be rendered via multitexturing.")
-    .def_static("MakeFromYUVAPixmaps", &SkImage::MakeFromYUVAPixmaps,
-        "Creates SkImage from pixmap array representing YUVA data.")
-    .def_static("MakeFromYUVTexturesCopy", &SkImage::MakeFromYUVTexturesCopy,
-        "To be deprecated.")
-    .def_static("MakeFromYUVTexturesCopyWithExternalBackend",
-        &SkImage::MakeFromYUVTexturesCopyWithExternalBackend,
-        "To be deprecated.")
-    .def_static("MakeFromNV12TexturesCopy", &SkImage::MakeFromNV12TexturesCopy,
-        "Creates SkImage from copy of nv12Textures, an array of textures on "
-        "GPU.")
-    .def_static("MakeFromNV12TexturesCopyWithExternalBackend",
-        &SkImage::MakeFromNV12TexturesCopyWithExternalBackend,
-        "Creates SkImage from copy of nv12Textures, an array of textures on "
-        "GPU.")
-    */
-    .def_static("MakeFromPicture",
-        [] (sk_sp<SkPicture>& picture, const SkISize& dimensions,
-            const SkMatrix* matrix, const SkPaint* paint,
-            SkImage::BitDepth bitDepth, const SkColorSpace* colorSpace) {
-            return SkImage::MakeFromPicture(
-                picture, dimensions, matrix, paint, bitDepth,
-                CloneColorSpace(colorSpace));
-        },
-        R"docstring(
-        Creates :py:class:`Image` from picture.
-
-        Returned :py:class:`Image` width and height are set by dimensions.
-        :py:class:`Image` draws picture with matrix and paint, set to bitDepth
-        and colorSpace.
-
-        If matrix is nullptr, draws with identity :py:class:`Matrix`. If paint
-        is nullptr, draws with default :py:class:`Paint`. colorSpace may be
-        nullptr.
-
-        :param skia.Picture picture: stream of drawing commands
-        :param skia.ISize dimensions:  width and height
-        :param skia.Matrix matrix: :py:class:`Matrix` to rotate, scale,
-            translate, and so on; may be nullptr
-        :param skia.Paint paint: :py:class:`Paint` to apply transparency,
-            filtering, and so on; may be nullptr
-        :param skia.Image.BitDepth bitDepth:    8-bit integer or 16-bit float:
-            per component
-        :param skia.ColorSpace colorSpace:  range of colors; may be nullptr
-        :return: created :py:class:`Image`, or nullptr
-        )docstring",
-        py::arg("picture"), py::arg("dimensions"), py::arg("matrix") = nullptr,
-        py::arg("paint") = nullptr,
-        py::arg("bitDepth") = SkImage::BitDepth::kU8,
-        py::arg("colorSpace") = nullptr)
     .def_static("MakeBackendTextureFromImage",
-        [] (GrContext* context, sk_sp<SkImage>& image,
+        [] (GrDirectContext* context, sk_sp<SkImage>& image,
             GrBackendTexture* backendTexture) {
             return SkImage::MakeBackendTextureFromSkImage(
                 context, image, backendTexture, nullptr);
@@ -1382,5 +1342,86 @@ image
         :return: true if back-end texture was created
         )docstring",
         py::arg("context"), py::arg("image"), py::arg("backendTexture"))
+    .def("asLegacyBitmap", &SkImage::asLegacyBitmap,
+        R"docstring(
+        Deprecated.
+
+        Creates raster :py:class:`Bitmap` with same pixels as :py:class:`Image`.
+        If legacyBitmapMode is :py:attr:`~Image.kRO_LegacyBitmapMode`, returned
+        bitmap is read-only and immutable. Returns true if :py:class:`Bitmap` is
+        stored in bitmap. Returns false and resets bitmap if :py:class:`Bitmap`
+        write did not succeed.
+
+        :param bitmap: storage for legacy :py:class:`Bitmap`
+        :param legacyBitmapMode: bitmap is read-only and immutable
+        :return: true if :py:class:`Bitmap` was created
+        )docstring",
+        py::arg("bitmap").none(false),
+        py::arg("legacyBitmapMode") = SkImage::kRO_LegacyBitmapMode)
+    .def("isLazyGenerated", &SkImage::isLazyGenerated,
+        R"docstring(
+        Returns true if :py:class:`Image` is backed by an image-generator or
+        other service that creates and caches its pixels or texture on-demand.
+
+        :return: true if :py:class:`Image` is created as needed
+        )docstring")
+    .def("makeColorSpace",
+        [] (const SkImage& image, const SkColorSpace* target,
+            GrDirectContext* direct) {
+            return image.makeColorSpace(CloneColorSpace(target), direct);
+        },
+        R"docstring(
+        Creates :py:class:`Image` in target :py:class:`ColorSpace`.
+
+        Returns nullptr if :py:class:`Image` could not be created.
+
+        Returns original :py:class:`Image` if it is in target
+        :py:class:`ColorSpace`. Otherwise, converts pixels from
+        :py:class:`Image` :py:class:`ColorSpace` to target
+        :py:class:`ColorSpace`. If :py:class:`Image` colorSpace() returns
+        nullptr, :py:class:`Image` :py:class:`ColorSpace` is assumed to be sRGB.
+
+        :param skia.ColorSpace target: :py:class:`ColorSpace` describing color
+            range of returned :py:class:`Image`
+        :return: created :py:class:`Image` in target :py:class:`ColorSpace`
+        )docstring",
+        py::arg("target"), py::arg("direct") = nullptr)
+    .def("makeColorTypeAndColorSpace",
+        [] (const SkImage& image, SkColorType ct, const SkColorSpace* cs,
+            GrDirectContext* direct) {
+            return image.makeColorTypeAndColorSpace(
+                ct, CloneColorSpace(cs), direct);
+        },
+        R"docstring(
+        Experimental.
+
+        Creates :py:class:`Image` in target :py:class:`ColorType` and
+        :py:class:`ColorSpace`. Returns nullptr if :py:class:`Image` could not
+        be created.
+
+        Returns original :py:class:`Image` if it is in target
+        :py:class:`ColorType` and :py:class:`ColorSpace`.
+
+        :param skia.ColorType targetColorType: :py:class:`ColorType` of returned
+            :py:class:`Image`
+        :param skia.ColorSpace targetColorSpace: :py:class:`ColorSpace` of
+            returned :py:class:`Image`
+        :return: created :py:class:`Image` in target :py:class:`ColorType` and
+            :py:class:`ColorSpace`
+        )docstring",
+        py::arg("targetColorType"), py::arg("targetColorSpace") = nullptr,
+        py::arg("direct") = nullptr)
+    .def("reinterpretColorSpace",
+        [] (const SkImage& image, const SkColorSpace* cs) {
+            return image.reinterpretColorSpace(CloneColorSpace(cs));
+        },
+        R"docstring(
+        Creates a new :py:class:`Image` identical to this one, but with a
+        different :py:class:`ColorSpace`.
+
+        This does not convert the underlying pixel data, so the resulting image
+        will draw differently.
+        )docstring",
+        py::arg("newColorSpace") = nullptr)
     ;
 }

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -12,8 +12,8 @@ public:
     SkRect cullRect() const override {
         PYBIND11_OVERLOAD_PURE(SkRect, SkPicture, cullRect);
     }
-    int approximateOpCount() const override {
-        PYBIND11_OVERLOAD_PURE(int, SkPicture, approximateOpCount);
+    int approximateOpCount(bool nested=false) const override {
+        PYBIND11_OVERLOAD_PURE(int, SkPicture, approximateOpCount, nested);
     }
     size_t approximateBytesUsed() const override {
         PYBIND11_OVERLOAD_PURE(size_t, SkPicture, approximateBytesUsed);

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -130,7 +130,8 @@ py::class_<SkPicture, PyPicture, sk_sp<SkPicture>, SkRefCnt>(
         than one operation, other calls may be optimized away.
 
         :return: approximate operation count
-        )docstring")
+        )docstring",
+        py::arg("nested") = false)
     .def("approximateBytesUsed", &SkPicture::approximateBytesUsed,
         R"docstring(
         Returns the approximate byte size of :py:class:`Picture`.

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -852,7 +852,7 @@ surface
         )docstring",
         py::arg("characterization"))
     .def("draw",
-        py::overload_cast<SkDeferredDisplayList*>(&SkSurface::draw),
+        py::overload_cast<sk_sp<const SkDeferredDisplayList>>(&SkSurface::draw),
         R"docstring(
         Draws deferred display list created using
         :py:class:`DeferredDisplayListRecorder`.

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -291,7 +291,12 @@ surface
         py::arg("mode"))
     .def("getContext", &SkSurface::getContext,
         R"docstring(
-        Returns the GPU context of the GPU surface.
+        Deprecated.
+        )docstring",
+        py::return_value_policy::reference_internal)
+    .def("recordingContext", &SkSurface::recordingContext,
+        R"docstring(
+        Returns the recording context being used by the :py:class:`Surface`.
 
         :return: GPU context, if available; nullptr otherwise
         )docstring",
@@ -1090,7 +1095,7 @@ surface
         py::arg("colorType"), py::arg("colorSpace"),
         py::arg("surfaceProps") = nullptr)
     .def_static("MakeRenderTarget",
-        py::overload_cast<GrContext*, SkBudgeted, const SkImageInfo&, int,
+        py::overload_cast<GrRecordingContext*, SkBudgeted, const SkImageInfo&, int,
         GrSurfaceOrigin, const SkSurfaceProps*, bool>(
             &SkSurface::MakeRenderTarget),
         R"docstring(
@@ -1135,7 +1140,7 @@ surface
         py::arg("surfaceProps") = nullptr,
         py::arg("shouldCreateWithMips") = false)
     .def_static("MakeRenderTarget",
-        py::overload_cast<GrContext*, SkBudgeted, const SkImageInfo&, int,
+        py::overload_cast<GrRecordingContext*, SkBudgeted, const SkImageInfo&, int,
             const SkSurfaceProps*>(&SkSurface::MakeRenderTarget),
         R"docstring(
         Returns :py:class:`Surface` on GPU indicated by context.
@@ -1167,7 +1172,7 @@ surface
         py::arg("context"), py::arg("budgeted"), py::arg("imageInfo"),
         py::arg("sampleCount"), py::arg("surfaceProps"))
     .def_static("MakeRenderTarget",
-        py::overload_cast<GrContext*, SkBudgeted, const SkImageInfo&>(
+        py::overload_cast<GrRecordingContext*, SkBudgeted, const SkImageInfo&>(
             &SkSurface::MakeRenderTarget),
         R"docstring(
         Returns :py:class:`Surface` on GPU indicated by context.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def opengl_context(request):
 
 @pytest.fixture(scope='session')
 def context(opengl_context):
-    yield skia.GrContext.MakeGL()
+    yield skia.GrDirectContext.MakeGL()
 
 
 @pytest.fixture(scope='module', params=['raster', 'gpu'])

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -185,14 +185,6 @@ def test_Bitmap_isOpaque(bitmap):
     assert isinstance(bitmap.isOpaque(), bool)
 
 
-def test_Bitmap_isVolatile(bitmap):
-    assert isinstance(bitmap.isVolatile(), bool)
-
-
-def test_Bitmap_setIsVolatile(bitmap):
-    bitmap.setIsVolatile()
-
-
 def test_Bitmap_reset(bitmap):
     bitmap.reset()
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -293,12 +293,6 @@ def test_FontMgr_matchFamilyStyleCharacter(fontmgr):
         (skia.Typeface, type(None)))
 
 
-def test_FontMgr_matchFaceStyle(fontmgr):
-    assert isinstance(
-        fontmgr.matchFaceStyle(skia.Typeface.MakeDefault(), skia.FontStyle()),
-        (skia.Typeface, type(None)))
-
-
 def test_FontMgr_makeFromData(fontmgr):
     assert fontmgr.makeFromData(skia.Data.MakeEmpty(), 0) is None
 

--- a/tests/test_grcontext.py
+++ b/tests/test_grcontext.py
@@ -95,19 +95,19 @@ def test_GrBackendFormat_isValid(backend_format):
 @pytest.fixture(scope='module')
 def backend_texture(context, gl_texture_info):
     return skia.GrBackendTexture(
-        256, 256, skia.GrMipMapped.kNo, gl_texture_info)
+        256, 256, skia.GrMipmapped.kNo, gl_texture_info)
 
 
 def test_GrBackendTexture_init_glInfo(gl_texture_info):
     assert isinstance(
-        skia.GrBackendTexture(128, 128, skia.GrMipMapped.kNo, gl_texture_info),
+        skia.GrBackendTexture(128, 128, skia.GrMipmapped.kNo, gl_texture_info),
         skia.GrBackendTexture)
 
 
 def test_GrBackendTexture_init_mockInfo(mock_texture_info):
     assert isinstance(
         skia.GrBackendTexture(
-            128, 128, skia.GrMipMapped.kNo, mock_texture_info),
+            128, 128, skia.GrMipmapped.kNo, mock_texture_info),
         skia.GrBackendTexture)
 
 
@@ -160,10 +160,6 @@ def test_GrBackendTexture_isSameTexture(backend_texture):
 @pytest.fixture
 def grflushinfo():
     return skia.GrFlushInfo()
-
-
-def test_GrFlushInfo_fFlag(grflushinfo):
-    assert isinstance(grflushinfo.fFlags, skia.GrFlushFlags)
 
 
 def test_GrFlushInfo_fNumSemaphores(grflushinfo):
@@ -373,15 +369,15 @@ def test_GrContext_defaultBackendFormat(context):
 
 
 @pytest.mark.parametrize('args', [
-    (64, 64, skia.GrBackendFormat(), skia.GrMipMapped.kNo,
+    (64, 64, skia.GrBackendFormat(), skia.GrMipmapped.kNo,
         skia.GrRenderable.kNo),
-    (64, 64, skia.ColorType.kRGBA_8888_ColorType, skia.GrMipMapped.kNo,
+    (64, 64, skia.ColorType.kRGBA_8888_ColorType, skia.GrMipmapped.kNo,
         skia.GrRenderable.kNo),
     pytest.param((skia.SurfaceCharacterization(),), marks=pytest.mark.skip),
-    (64, 64, skia.GrBackendFormat(), 0xFFFFFFFF, skia.GrMipMapped.kNo,
+    (64, 64, skia.GrBackendFormat(), 0xFFFFFFFF, skia.GrMipmapped.kNo,
         skia.GrRenderable.kNo),
     (64, 64, skia.ColorType.kRGBA_8888_ColorType, 0xFFFFFFFF,
-        skia.GrMipMapped.kNo, skia.GrRenderable.kNo),
+        skia.GrMipmapped.kNo, skia.GrRenderable.kNo),
     pytest.param(
         (skia.SurfaceCharacterization(), 0xFFFFFFFF),
         marks=pytest.mark.skip),
@@ -409,7 +405,7 @@ def test_GrContext_createBackendTexture_3(context, pixmap):
 def test_GrContext_updateBackendTexture_1(context):
     backend_texture = context.createBackendTexture(
         64, 64, skia.ColorType.kRGBA_8888_ColorType, 0xFFFFFFFF,
-        skia.GrMipMapped.kNo, skia.GrRenderable.kNo)
+        skia.GrMipmapped.kNo, skia.GrRenderable.kNo)
     assert isinstance(
         context.updateBackendTexture(backend_texture, skia.ColorBLACK), bool)
     context.deleteBackendTexture(backend_texture)
@@ -418,7 +414,7 @@ def test_GrContext_updateBackendTexture_1(context):
 def test_GrContext_updateBackendTexture_2(context, pixmap):
     backend_texture = context.createBackendTexture(
         64, 64, skia.ColorType.kRGBA_8888_ColorType, 0xFFFFFFFF,
-        skia.GrMipMapped.kNo, skia.GrRenderable.kNo)
+        skia.GrMipmapped.kNo, skia.GrRenderable.kNo)
     assert isinstance(
         context.updateBackendTexture(backend_texture, [pixmap]), bool)
     context.deleteBackendTexture(backend_texture)
@@ -431,10 +427,10 @@ def test_GrContext_compressedBackendFormat(context):
 
 
 @pytest.mark.parametrize('args', [
-    (64, 64, skia.GrBackendFormat(), 0xFFFFFFFF, skia.GrMipMapped.kNo),
-    (64, 64, skia.Image.kBC1_RGBA8_UNORM, 0xFFFFFFFF, skia.GrMipMapped.kNo),
-    (16, 16, skia.GrBackendFormat(), bytearray(256), skia.GrMipMapped.kNo),
-    (16, 16, skia.Image.kBC1_RGBA8_UNORM, bytearray(256), skia.GrMipMapped.kNo),
+    (64, 64, skia.GrBackendFormat(), 0xFFFFFFFF, skia.GrMipmapped.kNo),
+    (64, 64, skia.Image.kBC1_RGBA8_UNORM, 0xFFFFFFFF, skia.GrMipmapped.kNo),
+    (16, 16, skia.GrBackendFormat(), bytearray(256), skia.GrMipmapped.kNo),
+    (16, 16, skia.Image.kBC1_RGBA8_UNORM, bytearray(256), skia.GrMipmapped.kNo),
 ])
 def test_GrContext_createCompressedBackendTexture(context, args):
     backend_texture = context.createCompressedBackendTexture(*args)
@@ -467,29 +463,31 @@ def test_GrContext_precompileShader(context):
 
 def test_GrContext_ComputeImageSize(image):
     assert isinstance(
-        skia.GrContext.ComputeImageSize(image, skia.GrMipMapped.kYes),
+        skia.GrContext.ComputeImageSize(image, skia.GrMipmapped.kYes),
         int)
 
 
-def test_GrContext_MakeGL(context):
-    assert isinstance(context, skia.GrContext)
+def test_GrDirectContext_MakeGL(context):
+    assert isinstance(context, skia.GrDirectContext)
 
 
-def test_GrContext_MakeVulkan():
+@pytest.mark.skip(reason='Vulkan not supported yet.')
+def test_GrDirectContext_MakeVulkan():
     context = skia.GrVkBackendContext()
     options = skia.GrContextOptions()
     assert isinstance(
-        skia.GrContext.MakeVulkan(context),
-        (type(None), skia.GrContext))
+        skia.GrDirectContext.MakeVulkan(context),
+        (type(None), skia.GrDirectContext))
     assert isinstance(
-        skia.GrContext.MakeVulkan(context, options),
-        (type(None), skia.GrContext))
+        skia.GrDirectContext.MakeVulkan(context, options),
+        (type(None), skia.GrDirectContext))
 
 
-def test_GrContext_MakeMock():
+def test_GrDirectContext_MakeMock():
     assert isinstance(
-        skia.GrContext.MakeMock(skia.GrMockOptions(), skia.GrContextOptions()),
-        skia.GrContext)
+        skia.GrDirectContext.MakeMock(
+            skia.GrMockOptions(), skia.GrContextOptions()),
+        skia.GrDirectContext)
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_grcontext.py
+++ b/tests/test_grcontext.py
@@ -123,8 +123,8 @@ def test_GrBackendTexture_height(backend_texture):
     assert isinstance(backend_texture.height(), int)
 
 
-def test_GrBackendTexture_hasMipMaps(backend_texture):
-    assert isinstance(backend_texture.hasMipMaps(), bool)
+def test_GrBackendTexture_hasMipmaps(backend_texture):
+    assert isinstance(backend_texture.hasMipmaps(), bool)
 
 
 def test_GrBackendTexture_getGLTextureInfo(backend_texture, gl_texture_info):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -296,15 +296,6 @@ def test_Image_MakeFromEncoded(png_data):
     assert isinstance(skia.Image.MakeFromEncoded(png_data), skia.Image)
 
 
-def test_Image_DecodeToRaster(png_data):
-    assert isinstance(skia.Image.DecodeToRaster(png_data), skia.Image)
-
-
-def test_Image_DecodeToTexture(context, png_data):
-    assert isinstance(
-        skia.Image.DecodeToTexture(context, png_data), skia.Image)
-
-
 @pytest.fixture(scope='session')
 def compressed_data():
     return skia.Data.MakeUninitialized(128 * 128 * 32)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -205,11 +205,20 @@ def test_Image_encodeToData(image, args):
 def test_Image_refEncodedData(image):
     assert isinstance(image.refEncodedData(), skia.Data)
 
+def test_Image_makeSubset(image):
+    assert isinstance(image.makeSubset((10, 10)), skia.Image)
+
+def test_Image_hasMipmaps(image):
+    assert isinstance(image.hasMipmaps(), bool)
+
+@pytest.mark.skip(reason='Not implemented')
+def test_Image_withMipmaps(image):
+    raise NotImplementedError
 
 def test_Image_makeTextureImage(image, context):
     assert isinstance(
         image.makeTextureImage(
-            context, skia.GrMipMapped.kNo, skia.Budgeted.kNo),
+            context, skia.GrMipmapped.kNo, skia.Budgeted.kNo),
         skia.Image)
 
 
@@ -321,7 +330,7 @@ def test_Image_MakeRasterFromCompressed(compressed_data):
 def texture(context):
     backend_texture = context.createBackendTexture(
         128, 128, skia.ColorType.kRGBA_8888_ColorType,
-        skia.GrMipMapped.kNo, skia.GrRenderable.kNo)
+        skia.GrMipmapped.kNo, skia.GrRenderable.kNo)
     assert backend_texture.isValid()
     return backend_texture
 
@@ -345,7 +354,7 @@ def compressed_texture(context):
     if not backend_format.isValid():
         pytest.skip('Backend format is invalid.')
     backend_texture = context.createCompressedBackendTexture(
-        128, 128, backend_format, skia.Color4f.kRed, skia.GrMipMapped.kYes)
+        128, 128, backend_format, skia.Color4f.kRed, skia.GrMipmapped.kYes)
     if not backend_texture.isValid():
         pytest.skip('Backend texture is invalid.')
     return backend_texture

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -162,6 +162,7 @@ def test_Surface_characterize(surface):
     assert isinstance(surface.characterize(characterization), bool)
 
 
+# TODO: draw(DefferedDisplayList)
 # def test_Surface_draw(surface):
 #     surface.draw()
 


### PR DESCRIPTION
Major changes

- Implement inheritance hierarchy to `GrContext` and update APIs accordingly
- Remove `Image.DecodeToRaster` and `Image.DecodeToTexture`
- Remove `Bitmap` volatility APIs
- Remove `FontMgr.matchFaceStyle`
- Add a new argument to `Picture.approximateOpCount`