### PR TITLE
Fix path and typeface issues

### DIFF
--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -1182,12 +1182,15 @@ font
             std::vector<SkPath> paths;
             paths.reserve(glyphIDs.size());
             font.getPaths(
-                &glyphIDs[0],
+                glyphIDs.data(),
                 glyphIDs.size(),
                 [] (const SkPath* pathOrNull, const SkMatrix& mx, void* ctx) {
                     auto paths_ = static_cast<std::vector<SkPath>*>(ctx);
-                    if (pathOrNull)
-                        paths_->push_back(*pathOrNull);
+                    if (pathOrNull) {
+                        SkPath path;
+                        pathOrNull->transform(mx, &path);
+                        paths_->push_back(path);
+                    }
                 },
                 static_cast<void*>(&paths));
             if (paths.empty())

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -3,10 +3,9 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/iostream.h>
 
+using Axis = SkFontParameters::Variation::Axis;
 using Coordinate = SkFontArguments::VariationPosition::Coordinate;
-
 PYBIND11_MAKE_OPAQUE(std::vector<Coordinate>);
-
 
 namespace {
 
@@ -102,14 +101,53 @@ fontstyle
     ;
 
 // Typeface
+py::class_<SkFontParameters> fontparameters(m, "FontParameters");
+
+py::class_<SkFontParameters::Variation> variation(
+    fontparameters, "Variation",
+    R"docstring(
+    Parameters in a variation font axis.
+    )docstring");
+
+py::class_<Axis>(variation, "Axis")
+    .def(py::init<>())
+    .def("__repr__",
+        [] (const Axis& self) {
+            return py::str("Axis(tag={:x}, min={}, def={}, max={})").format(
+                self.tag, self.min, self.def, self.max);
+        })
+    .def_readwrite("tag", &Axis::tag,
+        R"docstring(
+        Four character identifier of the font axis (weight, width, slant,
+        italic...).
+        )docstring")
+    .def_readwrite("min", &Axis::min,
+        R"docstring(
+        Minimum value supported by this axis.
+        )docstring")
+    .def_readwrite("def", &Axis::def,
+        R"docstring(
+        Default value set by this axis.
+        )docstring")
+    .def_readwrite("max", &Axis::max,
+        R"docstring(
+        Maximum value supported by this axis. The maximum can equal the minimum.
+        )docstring")
+    .def("isHidden", &Axis::isHidden,
+        R"docstring(
+        Return whether this axis is recommended to be remain hidden in user
+        interfaces.
+        )docstring")
+    .def("setHidden", &Axis::setHidden,
+        R"docstring(
+        Set this axis to be remain hidden in user interfaces.
+        )docstring",
+        py::arg("hidden"))
+    ;
+
 py::class_<SkFontArguments> fontarguments(m, "FontArguments", R"docstring(
     Represents a set of actual arguments for a font.
     )docstring");
-
-// py::class_<SkFontArguments::Axis>(fontarguments, "Axis")
-//     .def_readwrite("fStyleValue", &SkFontArguments::Axis::fStyleValue)
-//     .def_readwrite("fTag", &SkFontArguments::Axis::fTag)
-//     ;
 
 py::class_<SkFontArguments::VariationPosition> variationposition(
     fontarguments, "VariationPosition",
@@ -124,6 +162,11 @@ py::class_<Coordinate>(
             return Coordinate({axis, value});
         }),
         py::arg("axis"), py::arg("value"))
+    .def("__repr__",
+        [] (const Coordinate& self) {
+            return py::str("Coordinate(axis={:x}, value={})").format(
+                self.axis, self.value);
+        })
     .def_readwrite("axis", &Coordinate::axis)
     .def_readwrite("value", &Coordinate::value)
     ;
@@ -158,7 +201,6 @@ fontarguments
         actually be indexed collections of fonts.
         )docstring",
         py::arg("collectionIndex"))
-    // .def("setAxes", &SkFontArguments::setAxes)
     .def("setVariationDesignPosition",
         &SkFontArguments::setVariationDesignPosition,
         R"docstring(
@@ -172,7 +214,6 @@ fontarguments
         )docstring",
         py::arg("position"))
     .def("getCollectionIndex", &SkFontArguments::getCollectionIndex)
-    // .def("getAxes", &SkFontArguments::getAxes)
     .def("getVariationDesignPosition",
         &SkFontArguments::getVariationDesignPosition)
     ;
@@ -251,16 +292,36 @@ typeface
         R"docstring(
         Returns true if the typeface claims to be fixed-pitch.
         )docstring")
-    .def("getVariationDesignPosition",
-        [] (const SkTypeface& typeface, int coordinateCount) {
-            std::vector<SkFontArguments::VariationPosition::Coordinate>
-                coords(coordinateCount);
-            auto count = typeface.getVariationDesignPosition(
-                &coords[0], coords.size());
+    .def("getVariationDesignParameters",
+        [] (const SkTypeface& typeface) {
+            auto count = typeface.getVariationDesignParameters(nullptr, 0);
             if (count == -1)
+                throw std::runtime_error("Failed to get; Likely no parameter");
+            std::vector<Axis> params(count);
+            if (count == 0)
+                return params;
+            auto actualCount = typeface.getVariationDesignParameters(
+                params.data(), params.size());
+            if (actualCount == -1)
                 throw std::runtime_error("Failed to get");
-            else if (count > int(coords.size()))
-                coords.erase(coords.begin() + count, coords.end());
+            return params;
+        },
+        R"docstring(
+        Returns the design variation parameters.
+
+        :return: List of axes.
+        :rtype: List[skia.FontParameters.Variation.Axis]
+        )docstring")
+    .def("getVariationDesignPosition",
+        [] (const SkTypeface& typeface) {
+            auto count = typeface.getVariationDesignPosition(nullptr, 0);
+            if (count == -1)
+                throw std::runtime_error("Failed to get; Likely no position");
+            std::vector<Coordinate> coords(count);
+            auto actualCount = typeface.getVariationDesignPosition(
+                coords.data(), coords.size());
+            if (actualCount == -1)
+                throw std::runtime_error("Failed to get");
             return coords;
         },
         R"docstring(
@@ -269,10 +330,7 @@ typeface
         :param int coordinateCount: the maximum number of entries to get.
         :return: list of coordinates
         :rtype: List[skia.FontArguments.VariationPosition.Coordinate]
-        )docstring",
-        py::arg("coordinateCount") = 10)
-    // .def("getVariationDesignParameters",
-    //     &SkTypeface::getVariationDesignParameters)
+        )docstring")
     .def("uniqueID", &SkTypeface::uniqueID,
         R"docstring(
         Return a 32bit value for this typeface, unique for the underlying font

--- a/src/skia/Path.cpp
+++ b/src/skia/Path.cpp
@@ -1983,10 +1983,8 @@ path
             SkScalar w, int pow2) {
             auto size = (1 + 2 * (1 << pow2));
             std::vector<SkPoint> pts(size);
-            auto result = SkPath::ConvertConicToQuads(
-                p0, p1, p2, w, &pts[0], pow2);
-            if (result < size)
-                pts.erase(pts.begin() + result, pts.end());
+            SkPath::ConvertConicToQuads(p0, p1, p2, w, &pts[0], pow2);
+            // TODO: Shall we return the return value?
             return pts;
         },
         R"docstring(
@@ -1997,12 +1995,9 @@ path
         quad count is 2 to the pow2. Every third point in array shares last
         :py:class:`Point` of previous quad and first :py:class:`Point` of next
         quad. Maximum possible return array size is given by:
-        (1 + 2 * (1 << pow2)) * sizeof(:py:class:`Point`).
+        (1 + 2 * (1 << pow2)).
 
-        Returns quad count used the approximation, which may be smaller than the
-        number requested.
-
-        conic weight determines the amount of influence conic control point has
+        Conic weight determines the amount of influence conic control point has
         on the curve. w less than one represents an elliptical section. w
         greater than one represents a hyperbolic section. w equal to one
         represents a parabolic section.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,3 +120,11 @@ def vertices():
         [skia.Point(1, 1), skia.Point(1, 0), skia.Point(0, 0)],
         [skia.ColorRED, skia.ColorRED, skia.ColorRED],
     )
+
+
+@pytest.fixture(scope='session')
+def ttf_path():
+    import os
+    root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(
+        root_dir, 'skia', 'resources', 'fonts', 'Distortable.ttf')

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -63,8 +63,8 @@ def test_FontArguments_getVariationDesignPosition(fontarguments):
 
 
 @pytest.fixture
-def typeface():
-    return skia.Typeface.MakeDefault()
+def typeface(ttf_path):
+    return skia.Typeface.MakeFromFile(ttf_path)
 
 
 def test_Typeface_fontStyle(typeface):
@@ -83,9 +83,24 @@ def test_Typeface_isFixedPitch(typeface):
     assert isinstance(typeface.isFixedPitch(), bool)
 
 
-@pytest.mark.xfail(reason='Fix me!')
 def test_Typeface_getVariationDesignParameters(typeface):
-    assert isinstance(typeface.getVariationDesignParameters(), list)
+    params = typeface.getVariationDesignParameters()
+    assert isinstance(params, list)
+    if len(params) > 0:
+        axis = params[0]
+        assert isinstance(axis, skia.FontParameters.Variation.Axis)
+        assert repr(axis)
+
+
+def test_Typeface_getVariationDesignPosition(typeface):
+    coordinates = typeface.getVariationDesignPosition()
+    assert isinstance(
+        coordinates, skia.FontArguments.VariationPosition.Coordinates)
+    if len(coordinates) > 0:
+        coordinate = coordinates[0]
+        assert isinstance(
+            coordinate, skia.FontArguments.VariationPosition.Coordinate)
+        assert repr(coordinate)
 
 
 def test_Typeface_uniqueID(typeface):

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -503,7 +503,9 @@ def test_Font_getPath(font, glyphs):
 
 
 def test_Font_getPaths(font, glyphs):
-    assert isinstance(font.getPaths(glyphs), list)
+    paths = font.getPaths(glyphs)
+    assert isinstance(paths, list)
+    assert paths[0] == font.getPath(glyphs[0])
 
 
 def test_Font_getMetrics(font):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -46,8 +46,19 @@ def test_Path_Iter_next(itr):
     assert isinstance(result[1], list)
 
 
-# def test_Path_Iter_conicWeight(itr):
-#     assert isinstance(itr.conicWeight())
+def test_Path_Iter_conicWeight():
+    path = skia.Path()
+    path.addOval((0, 0, 100, 100))
+
+    iterator = iter(path)
+    verb, points = iterator.next()
+    while verb != skia.Path.kDone_Verb:
+        print(verb)
+        assert isinstance(verb, skia.Path.Verb)
+        assert isinstance(points, list)
+        if verb == skia.Path.kConic_Verb:
+            assert iterator.conicWeight() == 0.7071067690849304
+        verb, points = iterator.next()
 
 
 def test_Path_Iter_isCloseLine(itr):
@@ -500,6 +511,7 @@ def test_Path_iter(path):
     for verb, points in path:
         assert isinstance(verb, skia.Path.Verb)
         assert isinstance(points, list)
+        # Iterator method does not work here.
 
 
 @pytest.fixture

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -50,15 +50,14 @@ def test_Path_Iter_conicWeight():
     path = skia.Path()
     path.addOval((0, 0, 100, 100))
 
-    iterator = iter(path)
-    verb, points = iterator.next()
+    itr = iter(path)
+    verb, points = itr.next()
     while verb != skia.Path.kDone_Verb:
-        print(verb)
         assert isinstance(verb, skia.Path.Verb)
         assert isinstance(points, list)
         if verb == skia.Path.kConic_Verb:
-            assert iterator.conicWeight() == 0.7071067690849304
-        verb, points = iterator.next()
+            assert itr.conicWeight() == 0.7071067690849304
+        verb, points = itr.next()
 
 
 def test_Path_Iter_isCloseLine(itr):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -481,8 +481,11 @@ def test_Path_IsCubicDegenerate(path):
 
 
 def test_Path_ConvertConicToQuads(path):
-    assert isinstance(skia.Path.ConvertConicToQuads(
-        skia.Point(0, 0), skia.Point(0, 1), skia.Point(1, 1), 1, 1), list)
+    # See https://fiddle.skia.org/c/@Path_ConvertConicToQuads
+    conic = [skia.Point(20, 170), skia.Point(80, 170), skia.Point(80, 230)]
+    quads = skia.Path.ConvertConicToQuads(conic[0], conic[1], conic[2], .25, 1)
+    assert isinstance(quads, list)
+    assert len(quads) == 5
 
 
 def test_Path_eq(path):


### PR DESCRIPTION
- Fix `Font.getPaths` scaling issue (#117)
- Update docstring for `Path.Iter.conicWeight` usage (resolve #116)
- Fix `ConvertConicToQuads` issue (#115)
- Implement `Op` and related functions (#114)
- Implement `Typeface.getVariationDesignParameters` (#112)