### PR TITLE
Require numpy for more than tests, libary doesn't work without it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,5 @@ changedir = tests
 commands = py.test {posargs}
 deps =
     pytest
-    numpy
     glfw
     pillow

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,10 @@ setup(
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     ext_modules=[extension],
-    install_requires=['pybind11>=2.6'],
+    install_requires=[
+        'numpy',
+        'pybind11>=2.6'
+    ],
     setup_requires=['pybind11>=2.6'],
     cmdclass={'build_ext': BuildExt},
     command_options={


### PR DESCRIPTION
The C++ code includes pybind11 bindings that assume numpy is loaded in the Python environment. It is listed as a dependency to run tests already, but the library is essentially useless without it (Canvas, Image, Matrix, Pixmap, Surface, and utils all use it).

See for example what happens if you [don't have it](https://github.com/justvanrossum/drawbot-skia/issues/33#issuecomment-894665838):

```
>>> import skia
>>> skia.Surface(100, 100)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'numpy'
```

Rather than expect downstream projects to compensate I think the right fix is to call it out here.
