### PR TITLE
Build wheels for Python 3.11 (fixes #182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         arch: [auto64]
         include:
           # - os: ubuntu-20.04
           #   arch: aarch64
-          - os: macos-10.15
+          - os: macos-11
             arch: arm64
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: cp*
           CIBW_SKIP: "*musllinux*"

--- a/setup.py
+++ b/setup.py
@@ -214,6 +214,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Multimedia :: Graphics',
         'Topic :: Scientific/Engineering :: Visualization',
     ],


### PR DESCRIPTION
- Upgrade `cibuildwheel` to the latest version so that the CI also builds wheels for Python 3.11
- Upgrade macOS version, given that the specified one is now deprecated and jobs no longer run

The build process seems now to complete successfully (I've enabled and executed it in my fork: https://github.com/lucach/skia-python/actions/runs/3396189748).