### PR TITLE
ci: build wheels also for linux/aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,34 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-12]
         arch: [auto64]
+        cp: ["cp3{7,8,9,10,11}"]
         include:
-          # - os: ubuntu-20.04
-          #   arch: aarch64
-          - os: macos-11
+          - os: macos-12
             arch: arm64
+            cp: "cp3{7,8,9,10,11}"
+          # aarch64 is emulated and takes longer, build one wheel per job
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp37
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp38
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp39
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp310
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp311
 
     steps:
       - uses: actions/checkout@v2
@@ -29,14 +46,18 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.arch != 'auto64'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.arch }}
+      
+      - name: Build pre-requisites
+        run: scripts/build_${{ runner.os }}.sh
+        shell: bash 
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BUILD: cp*
+          CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Binary package is available on PyPI:
 pip install skia-python
 ```
 
-Supported platforms:
+Supported platforms: Python 3.7-3.11 (CPython) on
 
 - Linux x86_64, aarch64
 - macOS x86_64, arm64

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -5,6 +5,9 @@ export PATH=${PWD}/depot_tools:$PATH
 EXTRA_CFLAGS=""
 
 if [[ $(uname -m) == "aarch64" ]]; then
+    # Compensate for emulation that makes `git clone` very slow on huge repos
+    git config --global http.postBuffer 1000000000
+    git config --global core.compression 0
     # Install ninja for aarch64
     yum -y install epel-release && \
         yum repolist && \


### PR DESCRIPTION
Wheels for linux/aarch64 were excluded from the CI workflow: the emulation makes the build extremely slow, and the job exceeds the 6 hours limit.

I started investigating several possible ways to work around this limitation. Experiments reveal that building `gn` and `skia` takes roughly 3 hours, and each wheel roughly 1 hour. It's common for large projects (see [matplotlib here](https://github.com/matplotlib/matplotlib/blob/1d0fc0c0ae7aa95efa4239bc83f9f97391946cf5/.github/workflows/cibuildwheel.yml#L81-L97)) to split wheels across jobs, creating one job per wheel.

I've experimented with several different configurations, and the one proposed in this PR seems to work quite consistently.
It's still hugely inefficient: the next step would be to split also the step of building `gn` and `skia` into a separate job, and inject them into the container used by `cibuildwheels`. I'd keep things simple though, unless deemed necessary, until a proper caching mechanism is implemented by `cibuildwheels`.

---

Note. Sporadically, an extremely slow runner can pick up the job and cause a timeout for one specific job. Since one year, though, it's possible to [manually re-run a single job in case of failure](https://github.blog/2022-03-16-save-time-partial-re-runs-github-actions/). I think that is a small enough (if any) price to pay for getting the extra wheels.