### PR TITLE
ci: build wheels also for linux/aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,37 +9,91 @@ on:
     types: [published]
 
 jobs:
+  prebuild_linux_aarch64:
+    name: Build skia on linux/aarch64
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/cache@v3
+        id: cache-skia
+        with:
+          path: |
+            gn
+            skia
+          key: linux-aarch64-skia-${{ github.sha }}
+      - name: Pre-fetch skia deps
+        run: git config --global core.compression 0 && cd skia && python tools/git-sync-deps
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Build skia
+        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.12.1/cibuildwheel/resources/pinned_docker_images.cfg
+        uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-03-05-271004f
+        if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
+        with:
+          args: bash -c "git config --global --add safe.directory '*' &&
+                         bash scripts/build_Linux.sh &&
+                         chmod a+rwx -R skia"
+
   build_wheels:
-    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }})
+    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
+    needs: prebuild_linux_aarch64
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-12]
         arch: [auto64]
+        cp: ["cp3{7,8,9,10,11}"]
         include:
-          # - os: ubuntu-20.04
-          #   arch: aarch64
-          - os: macos-11
+          - os: macos-12
             arch: arm64
+            cp: "cp3{7,8,9,10,11}"
+          # aarch64 is emulated and takes longer, build one wheel per job
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp37
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp38
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp39
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp310
+          - os: ubuntu-22.04
+            arch: aarch64
+            cp: cp311
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
+      - uses: actions/cache/restore@v3
+        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
+        with:
+          path: |
+            gn
+            skia
+          key: linux-aarch64-skia-${{ github.sha }}
+
       - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.arch != 'auto64'
-        uses: docker/setup-qemu-action@v1
+        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BUILD: cp*
+          CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }}
+          CIBW_ENVIRONMENT_LINUX: CI_SKIP_BUILD=true
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_BUILD: pip install pybind11 numpy
           CIBW_TEST_REQUIRES: pytest pillow glfw
@@ -49,7 +103,7 @@ jobs:
             xvfb-run -s "-screen 0 640x480x24" python -m pytest {project}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -58,14 +112,14 @@ jobs:
     needs: [build_wheels]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.8'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
@@ -89,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Binary package is available on PyPI:
 pip install skia-python
 ```
 
-Supported platforms:
+Supported platforms: Python 3.7-3.11 (CPython) on
 
 - Linux x86_64, aarch64
 - macOS x86_64, arm64

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -22,6 +22,11 @@ yum install -y \
     yum clean all && \
     rm -rf /var/cache/yum
 
+if [[ $(uname -m) == "aarch64" ]] && [[ $CI_SKIP_BUILD == "true" ]]; then
+    # gn and skia already built in a previous job
+    exit 0
+fi
+
 # Build gn
 export CC=gcc
 export CXX=g++


### PR DESCRIPTION
Wheels for linux/aarch64 were excluded from the CI workflow: the emulation makes the build extremely slow, and the job exceeds the 6 hours limit.

I started investigating several possible ways to work around this limitation. Experiments reveal that building gn and skia takes roughly 3 hours, and each wheel roughly 1 hour. It's common for large projects (see [matplotlib here](https://github.com/matplotlib/matplotlib/blob/1d0fc0c0ae7aa95efa4239bc83f9f97391946cf5/.github/workflows/cibuildwheel.yml#L81-L97)) to split wheels across jobs, creating one wheel per job.

I've experimented with several different configurations, and the one proposed in this PR seems to work consistently. Although it would be feasible for a job to build skia and one wheel (3hrs + 1hr = ~4hrs), sometimes GitHub workers are extremely slow and that would still exceed the timeout.
As a solution, I've split also the step of building gn and skia into a separate job, which get then injected into the container used by cibuildwheels.

This makes the CI setup a bit more complicated, but I think it's a small enough price to pay for getting the extra wheels.

I've also updated deprecated GitHub actions (which are going eventually to fail soon) and clarified for which versions wheels are built (so that we are also ready whenever the upcoming Python 3.12 will be out).