### PR TITLE
M117 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Build docs
         run: |
           python -m pip install -f dist skia-python
-          python -m pip install sphinx sphinx-rtd-theme
+          python -m pip install sphinx==6.2.1 sphinx-rtd-theme
           python setup.py build_sphinx
 
       - name: Deploy docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Build docs
         run: |
-          python -m pip install -f dist skia-python
+          python -m pip install --pre -f dist skia-python
           python -m pip install sphinx==6.2.1 sphinx-rtd-theme
           python setup.py build_sphinx
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           path: |
             gn
             skia
-          key: linux-aarch64-skia-${{ github.sha }}--3rd-party
+          key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Build Skia Proper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             skia
           key: linux-aarch64-skia-${{ github.sha }}
       - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m116-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m116-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m117-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m117-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Build skia

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,36 @@ on:
     types: [published]
 
 jobs:
+  prebuild_linux_aarch64_3rd_party:
+    name: Build skia bundled 3rd-party on linux/aarch64
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/cache@v3
+        id: cache-skia
+        with:
+          path: |
+            gn
+            skia
+          key: linux-aarch64-skia-${{ github.sha }}-3rd-party
+      - name: Pre-fetch skia deps
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m117-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m117-minimize-download.patch
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Build skia 3rd-Party
+        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.12.1/cibuildwheel/resources/pinned_docker_images.cfg
+        uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-03-05-271004f
+        if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
+        with:
+          args: bash -c "git config --global --add safe.directory '*' &&
+                         bash scripts/build_Linux.sh &&
+                         chmod a+rwx -R skia"
+
   prebuild_linux_aarch64:
     name: Build skia on linux/aarch64
+    needs: prebuild_linux_aarch64_3rd_party
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -23,18 +51,19 @@ jobs:
             gn
             skia
           key: linux-aarch64-skia-${{ github.sha }}
-      - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m117-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m117-minimize-download.patch
+      - uses: actions/cache/restore@v3
+        with:
+          path: |
+            gn
+            skia
+          key: linux-aarch64-skia-${{ github.sha }}--3rd-party
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      - name: Build skia
-        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.12.1/cibuildwheel/resources/pinned_docker_images.cfg
+      - name: Build Skia Proper
         uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-03-05-271004f
-        if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
         with:
           args: bash -c "git config --global --add safe.directory '*' &&
-                         bash scripts/build_Linux.sh &&
-                         chmod a+rwx -R skia"
+                         bash scripts/build_Linux.sh
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
@@ -93,7 +122,6 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }}
-          CIBW_ENVIRONMENT_LINUX: CI_SKIP_BUILD=true
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_BUILD: pip install pybind11 numpy
           CIBW_TEST_REQUIRES: pytest pillow glfw

--- a/README.m117.md
+++ b/README.m117.md
@@ -1,0 +1,3 @@
+SkSurface::flushAndSubmit() and SkSurface::flush() gone.
+"Remove legacy SkImage and SkSurface methods"
+m117: SkCanvas::flush() emulated

--- a/README.m117.md
+++ b/README.m117.md
@@ -10,7 +10,7 @@ Since m116:
 * PictureRecorder.FinishFlags removed
 * more PictureRecorder.beginRecording() overloads
 * new ScalarInfinity/ScalarNegativeInfinity defines
-* bug fix in TextBlob textcount
+* bug fix in TextBlob textcount (#200)
 
 * CI aarch64 build further split into 3rd-party and main to lower job time
 * documentation: locking to sphinx==6.2.1 as an interrim measure for splinx 7 breakage.

--- a/README.m117.md
+++ b/README.m117.md
@@ -1,3 +1,25 @@
-SkSurface::flushAndSubmit() and SkSurface::flush() gone.
-"Remove legacy SkImage and SkSurface methods"
-m117: SkCanvas::flush() emulated
+Since m116:
+
+* Surface::flushAndSubmit() and Surface::flush() now emulated
+  ("Remove legacy SkImage and SkSurface methods")
+* Canvas::flush() emulated
+* GrDirectContext/GrContext reorganized
+* Image::getBackendTexture() / Image::flush()/Image::flushAndSubmit() emulated
+* Image::encodeToData() from GPU backend now works (was broken between m87 and m116)
+* new RTreeFactory class added
+* PictureRecorder.FinishFlags removed
+* more PictureRecorder.beginRecording() overloads
+* new ScalarInfinity/ScalarNegativeInfinity defines
+* bug fix in TextBlob textcount
+
+* CI aarch64 build further split into 3rd-party and main to lower job time
+* documentation: locking to sphinx==6.2.1 as an interrim measure for splinx 7 breakage.
+                 uses "--pre" to build v11x.0by version of doc
+
+Since m87 (disabled in m116):
+* GrDirectContext::ComputeImageSize() now emulated
+* Image::MakeFromTexture() re-enabled
+* Image::makeSubset()/Image::flush() re-enabled
+* Image::makeTextureImage() / Image::MakeBackendTextureFromImage() emulated
+* Shader::Lerp() emulated
+* Surface::MakeFromBackendTexture()/Surface::MakeFromBackendRenderTarget() re-enabled

--- a/README.m117.md
+++ b/README.m117.md
@@ -3,7 +3,7 @@ Since m116:
 * Surface::flushAndSubmit() and Surface::flush() now emulated
   ("Remove legacy SkImage and SkSurface methods")
 * Canvas::flush() emulated
-* GrDirectContext/GrContext reorganized
+* GrDirectContext/GrContext reorganized (#198)
 * Image::getBackendTexture() / Image::flush()/Image::flushAndSubmit() emulated
 * Image::encodeToData() from GPU backend now works (was broken between m87 and m116)
 * new RTreeFactory class added
@@ -18,8 +18,8 @@ Since m116:
 
 Since m87 (disabled in m116):
 * GrDirectContext::ComputeImageSize() now emulated
-* Image::MakeFromTexture() re-enabled
+* Image::MakeFromTexture() re-enabled (#198)
 * Image::makeSubset()/Image::flush() re-enabled
 * Image::makeTextureImage() / Image::MakeBackendTextureFromImage() emulated
-* Shader::Lerp() emulated
-* Surface::MakeFromBackendTexture()/Surface::MakeFromBackendRenderTarget() re-enabled
+* Shader::Lerp() emulated (#198)
+* Surface::MakeFromBackendTexture()/Surface::MakeFromBackendRenderTarget() re-enabled (#198)

--- a/patch/skia-m117-minimize-download.patch
+++ b/patch/skia-m117-minimize-download.patch
@@ -2,7 +2,7 @@ diff --git a/DEPS b/DEPS
 index 7e743774c3..d32fab606f 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -19,51 +19,14 @@ vars = {
+@@ -19,51 +19,15 @@ vars = {
  #     ./tools/git-sync-deps
  deps = {
    "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
@@ -18,7 +18,7 @@ index 7e743774c3..d32fab606f 100644
    "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
 -  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@a0bca08de07c7d7651047bedc0b653cfaaa4f2ae",
 -  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@4a48a752e6a8bef6f222622f2b4926d5eb3bdeb3",
--  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
    "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@5769f13a6b9fafa3840726f06dde07e755501a16",
    "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@f94508edd60e26a015586c37c29104d6bdc26462",
 -  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",

--- a/patch/skia-m117-minimize-download.patch
+++ b/patch/skia-m117-minimize-download.patch
@@ -1,0 +1,68 @@
+diff --git a/DEPS b/DEPS
+index 7e743774c3..d32fab606f 100644
+--- a/DEPS
++++ b/DEPS
+@@ -19,51 +19,14 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@f7d7be8d2ff0bbee438b6030419a0b13082de198",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@beaf20f90f1bf21d235c99d5b49b8bb507b722b2",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@ee69aa00ee8536f61db6a451f3858745cf587de6",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0944e71f4b2cb9a871bcbe353f95e889b64a611a",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@cb436cf0142b4cbe47aae94223443df7f82e2920",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@a0bca08de07c7d7651047bedc0b653cfaaa4f2ae",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@4a48a752e6a8bef6f222622f2b4926d5eb3bdeb3",
+-  "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@5769f13a6b9fafa3840726f06dde07e755501a16",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@f94508edd60e26a015586c37c29104d6bdc26462",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@f49462dc93784bf34148715eee36ab6697ca0b35",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@0fb779c1e169fe6c229cd1fa9cc6ea6feeb441da",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@ed683925e4897a84b3bffc5c1414c85b97a129a3",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@386707c6d19b974ca2e3db7f5c61873813c6fe44",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@fd7bb21c0cb56e8a82e9bfa376164b842f433f3b",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/sfntly"                 : "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git@b55ff303ea2f9e26702b514cf6a3196a2e3e2974",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@729e92f8ae07d7b695bdcf346318dec4d11d899e",
+-  "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+-  "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@c46d48f777b73fa492cdc6424e54e4004bd9ee01",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@bccaa94db814af33d8ef05c153e7c34d8bd4d685",
+-  "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@124a9665e464ef98b8b718d572d5f329311061eb",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@4a9881fe9b32086d4ceac89a498b0dd34084b574",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@443539891c4c1eb3ca4ed891d251cbf4097c9a9c",
+-  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@450ead13e1064584da027d91192bd7bfb724640f",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@1d8188a974ccd08caffb5bd7fec58751e0c7d786",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@c876c8f87101c5a75f6014b0f832499afeb65b73",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 85badfdf0f..6537cd45f0 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.15'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -4,14 +4,11 @@ export PATH=${PWD}/depot_tools:$PATH
 
 EXTRA_CFLAGS=""
 
-if [[ $(uname -m) == "aarch64" ]]; then
-    # Install ninja for aarch64
-    yum -y install epel-release && \
-        yum repolist && \
-        yum install -y ninja-build && \
-        ln -s ninja-build /usr/bin/ninja &&
-        mv depot_tools/ninja depot_tools/ninja.bak
-fi
+export CC=gcc
+export CXX=g++
+export AR=ar
+export CFLAGS="-Wno-deprecated-copy"
+export LDFLAGS="-lrt"
 
 # Install system dependencies
 if [[ $EUID -eq 0 ]]; then
@@ -25,17 +22,35 @@ if [[ $EUID -eq 0 ]]; then
         rm -rf /var/cache/yum
 fi
 
-if [[ $(uname -m) == "aarch64" ]] && [[ $CI_SKIP_BUILD == "true" ]]; then
-    # gn and skia already built in a previous job
+# Wheel-building needs fontconfig-devel from above.
+# Simply quit, if it looks like a previous run was successful:
+if [[ -f "skia/out/Release/libskia.a" ]] ; then
     exit 0
 fi
 
+if [[ $(uname -m) == "aarch64" ]]; then
+    # Install ninja for aarch64
+    yum -y install epel-release && \
+        yum repolist && \
+        yum install -y ninja-build && \
+        ln -s ninja-build /usr/bin/ninja &&
+        mv depot_tools/ninja depot_tools/ninja.bak
+fi
+
+# libicu.a is the largest 3rd-party; if it already exists, we run ninja
+# a 2nd time and exit.
+# Running ninja a 2nd-time is safe - it is no-ops if skia is already built too.
+# The 3rd-party libraries below are built in size-order; we built libicu last to signal
+# having built most of them.
+if [[ -f "skia/out/Release/libicu.a" ]] ; then
+    cd skia && \
+        ninja -C out/Release && \
+        cd ..
+    exit $?
+fi
+### 2nd round<->1st round ###
+
 # Build gn
-export CC=gcc
-export CXX=g++
-export AR=ar
-export CFLAGS="-Wno-deprecated-copy"
-export LDFLAGS="-lrt"
 git clone https://gn.googlesource.com/gn && \
     cd gn && \
     git checkout fe330c0ae1ec29db30b6f830e50771a335e071fb && \
@@ -61,5 +76,12 @@ skia_use_system_freetype2=false
 extra_cflags_cc=[\"-frtti\"]
 extra_ldflags=[\"-lrt\"]
 " && \
-    ninja -C out/Release && \
+    ninja -C out/Release \
+          third_party/freetype2 \
+          third_party/libwebp \
+          third_party/dng_sdk \
+          third_party/harfbuzz \
+          third_party/icu && \
+    ( ( [[ $(uname -m) == "aarch64" ]] && echo "On aarch64 - Please run me again!" ) || \
+          ninja -C out/Release ) && \
     cd ..

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -45,7 +45,7 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m116-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m117-minimize-download.patch && \
     patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,6 +4,7 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
+    patch -p1 < ../patch/skia-m117-minimize-download.patch && \
     patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,6 +22,7 @@ function apply_patch {
 }
 
 cd skia && \
+    patch -p1 < ../patch/skia-m117-minimize-download.patch && \
     patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '116.0b1'
+__version__ = '116.0b2'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '117.0b2'
+__version__ = '117.0b3'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ else:
     LIBRARIES = [
         'dl',
         'fontconfig',
-        'freetype',
         'GL',
         'expat',
     ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '116.0b2'
+__version__ = '117.0b2'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/Canvas.cpp
+++ b/src/skia/Canvas.cpp
@@ -385,7 +385,12 @@ canvas
         :return: true if :py:class:`SurfaceProps` was copied
         )docstring",
         py::arg("props"))
-    .def("flush", &SkCanvas::flush,
+    .def("flush",
+        [] (const SkCanvas& canvas) {
+            if (auto dContext = GrAsDirectContext(canvas.recordingContext())) {
+                dContext->flushAndSubmit();
+            }
+        },
         R"docstring(
         Triggers the immediate execution of all pending draw operations.
 

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -820,10 +820,12 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     //     "traceMemoryDump.")
     .def("supportsDistanceFieldText", &GrDirectContext::supportsDistanceFieldText)
     .def("storeVkPipelineCacheData", &GrDirectContext::storeVkPipelineCacheData)
-/*
-    .def_static("ComputeImageSize", &GrDirectContext::ComputeImageSize,
+    .def_static("ComputeImageSize",
+        [] (sk_sp<SkImage> image, GrMipmapped mapped, bool useNextPow2) {
+            // REVISIT: process GrMipmapped and useNextPow2 = true
+            return image->textureSize();
+        },
         py::arg("image"), py::arg("mipMapped"), py::arg("useNextPow2") = false)
-*/
     .def("defaultBackendFormat", &GrDirectContext::defaultBackendFormat,
         R"docstring(
         Retrieve the default :py:class:`GrBackendFormat` for a given

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -523,7 +523,7 @@ py::class_<GrRecordingContext, sk_sp<GrRecordingContext>, GrImageContext>(
     //     py::overload_cast<>(&GrRecordingContext::priv, py::const_))
     ;
 
-py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrContext")
+py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDirectContext")
     .def("resetContext", &GrDirectContext::resetContext,
         R"docstring(
         The :py:class:`GrContext` normally assumes that no outsider is setting
@@ -1195,7 +1195,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrCo
         )docstring")
     ;
 
-m.attr("GrDirectContext") = m.attr("GrContext");
+m.attr("GrContext") = m.attr("GrDirectContext");
 
 initGrContext_gl(m);
 initGrContext_vk(m);

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -3,6 +3,7 @@
 #include <include/core/SkSamplingOptions.h>
 #include <include/gpu/GrBackendSurface.h>
 #include <include/gpu/GpuTypes.h>
+#include <include/gpu/ganesh/SkImageGanesh.h>
 #include <include/encode/SkJpegEncoder.h>
 #include <include/encode/SkPngEncoder.h>
 #include <include/encode/SkWebpEncoder.h>
@@ -674,6 +675,7 @@ image
         :return: created :py:class:`Image`, or nullptr
         )docstring",
         py::arg("data"), py::arg("width"), py::arg("height"), py::arg("type"))
+*/
     .def_static("MakeFromTexture",
         [] (GrRecordingContext* context, const GrBackendTexture& texture,
             GrSurfaceOrigin origin, SkColorType colorType,
@@ -698,6 +700,7 @@ image
         py::arg("context"), py::arg("texture"), py::arg("origin"),
         py::arg("colorType"), py::arg("alphaType"),
         py::arg("colorSpace") = nullptr)
+/*
     .def_static("MakeFromCompressedTexture",
         [] (GrRecordingContext* context, const GrBackendTexture& texture,
             GrSurfaceOrigin origin, SkAlphaType alphaType,

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1572,8 +1572,10 @@ image
 
         :return: encoded :py:class:`Image`, or nullptr
         )docstring")
-/*
-    .def("makeSubset", &SkImage::makeSubset,
+    .def("makeSubset",
+        [] (SkImage& image, const SkIRect& subset, GrDirectContext* direct) {
+            return image.makeSubset(direct, subset);
+        },
         R"docstring(
         Returns subset of :py:class:`Image`.
 
@@ -1588,7 +1590,6 @@ image
         :return: partial or full :py:class:`Image`, or nullptr
         )docstring",
         py::arg("subset"), py::arg("direct") = nullptr)
-*/
     .def("hasMipmaps", &SkImage::hasMipmaps,
         R"docstring(
         Returns true if the image has mipmap levels.

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1264,9 +1264,8 @@ image
         :return: true if :py:class:`Image` can be drawn
         )docstring",
         py::arg("context") = nullptr)
-/*
     .def("flush",
-        py::overload_cast<GrDirectContext*, const GrFlushInfo&>(&SkImage::flush),
+        py::overload_cast<GrDirectContext*, const GrFlushInfo&>(&GrDirectContext::flush),
         R"docstring(
         Flushes any pending uses of texture-backed images in the GPU backend. If
         the image is not texture-backed (including promise texture images) or if
@@ -1284,16 +1283,16 @@ image
         )docstring"
         )
     .def("flush",
-        py::overload_cast<GrDirectContext*>(&SkImage::flush),
+        py::overload_cast<GrDirectContext*>(&GrDirectContext::flush),
         py::arg("context").none(false))
-    .def("flushAndSubmit", &SkImage::flushAndSubmit,
+    .def("flushAndSubmit", &GrDirectContext::flushAndSubmit,
         R"docstring(
         Version of :py:meth:`flush` that uses a default GrFlushInfo.
 
         Also submits the flushed work to the GPU.
         )docstring",
         py::arg("context").none(false))
-    .def("getBackendTexture", &SkImage::getBackendTexture,
+    .def("getBackendTexture", &SkImages::GetBackendTextureFromImage,
         R"docstring(
         Retrieves the back-end texture. If :py:class:`Image` has no back-end
         texture, an invalid object is returned. Call
@@ -1308,7 +1307,6 @@ image
         :return: back-end API texture handle; invalid on failure
         )docstring",
         py::arg("flushPendingGrContextIO"), py::arg("origin") = nullptr)
-*/
     .def("readPixels", &ImageReadPixels,
         R"docstring(
         Copies a :py:class:`Rect` of pixels from :py:class:`Image` to dst. Copy
@@ -1705,11 +1703,10 @@ image
         py::arg("context"), py::arg("filter"), py::arg("subset"),
         py::arg("clipBounds"), py::arg("outSubset").none(false),
         py::arg("offset").none(false))
-/*
     .def_static("MakeBackendTextureFromImage",
         [] (GrDirectContext* context, sk_sp<SkImage>& image,
             GrBackendTexture* backendTexture) {
-            return SkImages::GetBackendTextureFromImage(
+            return SkImages::MakeBackendTextureFromImage(
                 context, image, backendTexture, nullptr);
         },
         R"docstring(
@@ -1734,7 +1731,6 @@ image
         :return: true if back-end texture was created
         )docstring",
         py::arg("context"), py::arg("image"), py::arg("backendTexture"))
-*/
     .def("asLegacyBitmap", &SkImage::asLegacyBitmap,
         R"docstring(
         Deprecated.

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -148,8 +148,8 @@ sk_sp<SkImage> ImageConvert(
         at = image.alphaType();
     if (at == image.alphaType()) {
         if (ct == image.colorType())
-            return image.makeColorSpace(CloneColorSpace(cs));
-        return image.makeColorTypeAndColorSpace(ct, CloneColorSpace(cs));
+            return image.makeColorSpace(nullptr, CloneColorSpace(cs));
+        return image.makeColorTypeAndColorSpace(nullptr, ct, CloneColorSpace(cs));
     }
 
     auto imageInfo = SkImageInfo::Make(
@@ -1757,7 +1757,7 @@ image
     .def("makeColorSpace",
         [] (const SkImage& image, const SkColorSpace* target,
             GrDirectContext* direct) {
-            return image.makeColorSpace(CloneColorSpace(target), direct);
+            return image.makeColorSpace(direct, CloneColorSpace(target));
         },
         R"docstring(
         Creates :py:class:`Image` in target :py:class:`ColorSpace`.
@@ -1779,7 +1779,7 @@ image
         [] (const SkImage& image, SkColorType ct, const SkColorSpace* cs,
             GrDirectContext* direct) {
             return image.makeColorTypeAndColorSpace(
-                ct, CloneColorSpace(cs), direct);
+                direct, ct, CloneColorSpace(cs));
         },
         R"docstring(
         Experimental.

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1299,7 +1299,12 @@ image
         Also submits the flushed work to the GPU.
         )docstring",
         py::arg("context").none(false))
-    .def("getBackendTexture", &SkImages::GetBackendTextureFromImage,
+    .def("getBackendTexture",
+        [] (const SkImage* img,
+            bool flushPendingGrContextIO,
+            GrSurfaceOrigin* origin) {
+            return SkImages::GetBackendTextureFromImage(img, nullptr, flushPendingGrContextIO, origin);
+        },
         R"docstring(
         Retrieves the back-end texture. If :py:class:`Image` has no back-end
         texture, an invalid object is returned. Call
@@ -1607,7 +1612,13 @@ image
         Returns an image with the same "base" pixels as the this image, but with
         mipmap levels automatically generated and attached.
         )docstring")
-    .def("makeTextureImage", &SkImages::TextureFromImage,
+    .def("makeTextureImage",
+        [] (const SkImage* img,
+            GrDirectContext* ctx,
+            skgpu::Mipmapped m,
+            skgpu::Budgeted b) {
+            return SkImages::TextureFromImage(ctx, img, m, b);
+        },
         R"docstring(
         Returns :py:class:`Image` backed by GPU texture associated with context.
 

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1660,7 +1660,8 @@ image
         Returns nullptr if backed by GPU texture and copy fails.
 
         :return: raster image, lazy image, or nullptr
-        )docstring")
+        )docstring",
+        py::arg("context") = nullptr)
     .def("makeRasterImage", py::overload_cast<SkImage::CachingHint>(&SkImage::makeRasterImage, py::const_),
         R"docstring(
         Returns raster image.

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -94,7 +94,8 @@ sk_sp<SkImage> ImageOpen(py::object fp) {
 
 void ImageSave(const SkImage& image, py::object fp,
                SkEncodedImageFormat format, int quality) {
-    sk_sp<SkData> data = image.refEncodedData();
+    sk_sp<SkData> data;
+    sk_sp<SkImage> copy = image.makeRasterImage(); // isTextureBacked/isLazyGenerated images needs this
     switch (format) {
     case SkEncodedImageFormat::kWEBP:
         {
@@ -108,7 +109,7 @@ void ImageSave(const SkImage& image, py::object fp,
                 // which follows Blink and WebPConfigInit.
                 options.fQuality = 70;
             }
-            data = SkWebpEncoder::Encode(nullptr, &image, options);
+            data = SkWebpEncoder::Encode(nullptr, copy.get(), options);
         }
         break;
 
@@ -116,7 +117,7 @@ void ImageSave(const SkImage& image, py::object fp,
         {
             SkJpegEncoder::Options options;
             options.fQuality = quality;
-            data = SkJpegEncoder::Encode(nullptr, &image, options);
+            data = SkJpegEncoder::Encode(nullptr, copy.get(), options);
         }
         break;
 
@@ -124,7 +125,7 @@ void ImageSave(const SkImage& image, py::object fp,
     default:
         {
              SkPngEncoder::Options options; // Not used
-             data = SkPngEncoder::Encode(nullptr, &image, {});
+             data = SkPngEncoder::Encode(nullptr, copy.get(), {});
         }
         break;
     }
@@ -1489,7 +1490,8 @@ image
         py::arg("cachingHint") = SkImage::kAllow_CachingHint)
     .def("encodeToData",
         [] (SkImage& image, SkEncodedImageFormat format, int quality) {
-            sk_sp<SkData> data = image.refEncodedData();
+            sk_sp<SkData> data;
+            sk_sp<SkImage> copy = image.makeRasterImage(); // isTextureBacked/isLazyGenerated images needs this
             switch (format) {
             case SkEncodedImageFormat::kWEBP:
                 {
@@ -1503,7 +1505,7 @@ image
                     // which follows Blink and WebPConfigInit.
                     options.fQuality = 70;
                 }
-                data = SkWebpEncoder::Encode(nullptr, &image, options);
+                data = SkWebpEncoder::Encode(nullptr, copy.get(), options);
                 }
                 break;
 
@@ -1511,7 +1513,7 @@ image
                 {
                 SkJpegEncoder::Options options;
                 options.fQuality = quality;
-                data = SkJpegEncoder::Encode(nullptr, &image, options);
+                data = SkJpegEncoder::Encode(nullptr, copy.get(), options);
                 }
                 break;
 
@@ -1519,7 +1521,7 @@ image
             default:
                 {
                 SkPngEncoder::Options options; // Not used
-                data = SkPngEncoder::Encode(nullptr, &image, {});
+                data = SkPngEncoder::Encode(nullptr, copy.get(), {});
                 }
                 break;
             }

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1265,7 +1265,9 @@ image
         )docstring",
         py::arg("context") = nullptr)
     .def("flush",
-        py::overload_cast<GrDirectContext*, const GrFlushInfo&>(&GrDirectContext::flush),
+        [] (sk_sp<const SkImage> image, sk_sp<GrDirectContext> context, const GrFlushInfo& info) {
+            return context->flush(image, info);
+        },
         R"docstring(
         Flushes any pending uses of texture-backed images in the GPU backend. If
         the image is not texture-backed (including promise texture images) or if
@@ -1283,9 +1285,14 @@ image
         )docstring"
         )
     .def("flush",
-        py::overload_cast<GrDirectContext*>(&GrDirectContext::flush),
+        [] (sk_sp<const SkImage> image, sk_sp<GrDirectContext> context) {
+            return context->flush(image);
+        },
         py::arg("context").none(false))
-    .def("flushAndSubmit", &GrDirectContext::flushAndSubmit,
+    .def("flushAndSubmit",
+        [] (sk_sp<const SkImage> image, sk_sp<GrDirectContext> context) {
+            return context->flushAndSubmit(image);
+        },
         R"docstring(
         Version of :py:meth:`flush` that uses a default GrFlushInfo.
 

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1646,8 +1646,7 @@ image
         :return: created :py:class:`Image`, or nullptr
         )docstring",
         py::arg("context").none(false), py::arg("mipMapped") = GrMipmapped::kNo,
-        py::arg("budgeted") = SkBudgeted::kYes)
-*/
+        py::arg("budgeted") = skgpu::Budgeted::kYes)
     .def("makeNonTextureImage", &SkImage::makeNonTextureImage,
         R"docstring(
         Returns raster image or lazy image.

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1600,8 +1600,7 @@ image
         Returns an image with the same "base" pixels as the this image, but with
         mipmap levels automatically generated and attached.
         )docstring")
-/*
-    .def("makeTextureImage", &SkImage::makeTextureImage,
+    .def("makeTextureImage", &SkImages::TextureFromImage,
         R"docstring(
         Returns :py:class:`Image` backed by GPU texture associated with context.
 

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -324,6 +324,13 @@ picturerecorder
     //         &SkPictureRecorder::beginRecording),
     //     "Returns the canvas that records the drawing commands.")
     .def("beginRecording",
+        py::overload_cast<const SkRect&, sk_sp<SkBBoxHierarchy>>(
+            &SkPictureRecorder::beginRecording),
+        R"docstring(
+        Returns the canvas that records the drawing commands.
+        )docstring",
+        py::arg("bounds"), py::arg("bbh"))
+    .def("beginRecording",
         [] (SkPictureRecorder& recorder, const SkRect& bounds) {
             return recorder.beginRecording(bounds, nullptr);
         },

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -2,6 +2,7 @@
 #include <include/core/SkDrawable.h>
 #include <include/core/SkBBHFactory.h>
 #include <include/core/SkPictureRecorder.h>
+#include <pybind11/operators.h>
 
 namespace {
 
@@ -272,6 +273,12 @@ py::class_<SkDrawable, sk_sp<SkDrawable>, SkFlattenable>(m, "Drawable",
     ;
 
 py::class_<SkBBHFactory>(m, "BBHFactory");
+
+py::class_<SkRTreeFactory, SkBBHFactory> rTreeFactory(m, "RTreeFactory");
+
+rTreeFactory
+    .def(py::init<>())
+    .def("__call__", &SkBBHFactory::operator());
 
 py::class_<SkBBoxHierarchy, PyBBoxHierarchy, sk_sp<SkBBoxHierarchy>, SkRefCnt>
     bboxhierarchy(m, "BBoxHierarchy");

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -329,7 +329,8 @@ picturerecorder
         R"docstring(
         Returns the canvas that records the drawing commands.
         )docstring",
-        py::arg("bounds"), py::arg("bbh"))
+        py::arg("bounds"), py::arg("bbh"),
+        py::return_value_policy::reference_internal)
     .def("beginRecording",
         [] (SkPictureRecorder& recorder, const SkRect& bounds) {
             return recorder.beginRecording(bounds, nullptr);

--- a/src/skia/Picture.cpp
+++ b/src/skia/Picture.cpp
@@ -305,7 +305,10 @@ bboxhierarchy
 
 py::class_<SkPictureRecorder> picturerecorder(m, "PictureRecorder");
 
+/* m117: Remove slug-related #ifdefs from src/core */
+/*
 py::enum_<SkPictureRecorder::FinishFlags>(picturerecorder, "FinishFlags");
+*/
 
 picturerecorder
     .def(py::init())

--- a/src/skia/Scalar.cpp
+++ b/src/skia/Scalar.cpp
@@ -1,0 +1,7 @@
+#include "common.h"
+#include <include/core/SkScalar.h>
+
+void initScalar(py::module &m) {
+    m.attr("ScalarInfinity") = py::cast(std::numeric_limits<float>::infinity());
+    m.attr("ScalarNegativeInfinity") = py::cast(-std::numeric_limits<float>::infinity());
+}

--- a/src/skia/Shader.cpp
+++ b/src/skia/Shader.cpp
@@ -2,6 +2,7 @@
 #include <include/effects/SkRuntimeEffect.h>
 #include <include/effects/SkGradientShader.h>
 #include <include/effects/SkPerlinNoiseShader.h>
+#include <include/effects/SkBlenders.h>
 #include <pybind11/stl.h>
 
 #define GET_SKSCALAR_PTR(pos) \
@@ -190,15 +191,14 @@ py::class_<std::unique_ptr<int32_t>>(m, "Shaders")
                 blender, dst, src);
         },
         py::arg("blender"), py::arg("dst"), py::arg("src"))
-/*
     .def_static("Lerp",
         [] (SkScalar t, const SkShader& dst,
             const SkShader& src) {
-            return SkShaders::Lerp(
-                t, CloneFlattenable(dst), CloneFlattenable(src));
+            return SkShaders::Blend(
+                SkBlenders::Arithmetic(0, t, 1-t, 0, false),
+                CloneFlattenable(dst), CloneFlattenable(src));
         },
         py::arg("t"), py::arg("dst"), py::arg("src"))
-*/
     ;
 
 py::class_<SkGradientShader> gradientshader(m, "GradientShader");

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -1055,9 +1055,9 @@ surface
         [] (GrRecordingContext* context, const GrBackendRenderTarget& target,
             GrSurfaceOrigin origin, SkColorType colorType,
             sk_sp<SkColorSpace> colorSpace,
-            const SkSurfaceProps* surfaceProps, SkSurfaces::RenderTargetReleaseProc releaseProc, SkSurfaces::ReleaseContext releaseContext) {
+            const SkSurfaceProps* surfaceProps) {
             return SkSurfaces::WrapBackendRenderTarget(
-                context, target, origin, colorType, colorSpace, surfaceProps, releaseProc, releaseContext);
+                context, target, origin, colorType, colorSpace, surfaceProps, NULL, NULL);
         },
         R"docstring(
         Wraps a GPU-backed buffer into :py:class:`Surface`.
@@ -1090,7 +1090,7 @@ surface
         )docstring",
         py::arg("context"), py::arg("backendRenderTarget"), py::arg("origin"),
         py::arg("colorType"), py::arg("colorSpace"),
-        py::arg("surfaceProps") = nullptr, py::arg("releaseProc") = nullptr, py::arg("releaseContext") = nullptr)
+        py::arg("surfaceProps") = nullptr)
     .def_static("MakeRenderTarget",
         py::overload_cast<GrRecordingContext*, skgpu::Budgeted, const SkImageInfo&, int,
         GrSurfaceOrigin, const SkSurfaceProps*, bool>(

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -991,15 +991,14 @@ surface
             nullptr
         )docstring",
         py::arg("width"), py::arg("height"), py::arg("surfaceProps") = nullptr)
-/*
     .def_static("MakeFromBackendTexture",
-        [] (GrDirectContext* context, const GrBackendTexture& backendTexture,
+        [] (GrRecordingContext* context, const GrBackendTexture& backendTexture,
             GrSurfaceOrigin origin, int sampleCnt, SkColorType colorType,
             sk_sp<SkColorSpace> colorSpace,
-            const SkSurfaceProps* surfaceProps) {
+            const SkSurfaceProps* surfaceProps, RenderTargetReleaseProc releaseProc, ReleaseContext releaseContext) {
             return SkSurfaces::WrapBackendTexture(
                 context, backendTexture, origin, sampleCnt, colorType,
-                colorSpace, surfaceProps);
+                colorSpace, surfaceProps, releaseProc, releaseContext);
         },
         R"docstring(
         Wraps a GPU-backed texture into :py:class:`Surface`. Caller must ensure
@@ -1036,14 +1035,14 @@ surface
         )docstring",
         py::arg("context"), py::arg("backendTexture"), py::arg("origin"),
         py::arg("sampleCnt"), py::arg("colorType"), py::arg("colorSpace"),
-        py::arg("surfaceProps"))
+        py::arg("surfaceProps"), py::arg("releaseProc") = nullptr, py::arg("releaseContext") = nullptr)
     .def_static("MakeFromBackendRenderTarget",
-        [] (GrDirectContext* context, const GrBackendRenderTarget& target,
+        [] (GrRecordingContext* context, const GrBackendRenderTarget& target,
             GrSurfaceOrigin origin, SkColorType colorType,
             sk_sp<SkColorSpace> colorSpace,
-            const SkSurfaceProps* surfaceProps) {
+            const SkSurfaceProps* surfaceProps, RenderTargetReleaseProc releaseProc, ReleaseContext releaseContext) {
             return SkSurfaces::WrapBackendRenderTarget(
-                context, target, origin, colorType, colorSpace, surfaceProps);
+                context, target, origin, colorType, colorSpace, surfaceProps, releaseProc, releaseContext);
         },
         R"docstring(
         Wraps a GPU-backed buffer into :py:class:`Surface`.
@@ -1076,8 +1075,7 @@ surface
         )docstring",
         py::arg("context"), py::arg("backendRenderTarget"), py::arg("origin"),
         py::arg("colorType"), py::arg("colorSpace"),
-        py::arg("surfaceProps") = nullptr)
-*/
+        py::arg("surfaceProps") = nullptr, py::arg("releaseProc") = nullptr, py::arg("releaseContext") = nullptr)
     .def_static("MakeRenderTarget",
         py::overload_cast<GrRecordingContext*, skgpu::Budgeted, const SkImageInfo&, int,
         GrSurfaceOrigin, const SkSurfaceProps*, bool>(

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -1010,10 +1010,10 @@ surface
         [] (GrRecordingContext* context, const GrBackendTexture& backendTexture,
             GrSurfaceOrigin origin, int sampleCnt, SkColorType colorType,
             sk_sp<SkColorSpace> colorSpace,
-            const SkSurfaceProps* surfaceProps, SkSurfaces::RenderTargetReleaseProc releaseProc, SkSurfaces::ReleaseContext releaseContext) {
+            const SkSurfaceProps* surfaceProps) {
             return SkSurfaces::WrapBackendTexture(
                 context, backendTexture, origin, sampleCnt, colorType,
-                colorSpace, surfaceProps, releaseProc, releaseContext);
+                colorSpace, surfaceProps, NULL, NULL);
         },
         R"docstring(
         Wraps a GPU-backed texture into :py:class:`Surface`. Caller must ensure
@@ -1043,14 +1043,12 @@ surface
         :colorSpace:  range of colors; may be nullptr
         :surfaceProps:    LCD striping orientation and setting for device
             independent fonts; may be nullptr
-        :textureReleaseProc:  function called when texture can be released
-        :releaseContext:  state passed to textureReleaseProc
         :return: :py:class:`Surface` if all parameters are valid; otherwise,
             nullptr
         )docstring",
         py::arg("context"), py::arg("backendTexture"), py::arg("origin"),
         py::arg("sampleCnt"), py::arg("colorType"), py::arg("colorSpace"),
-        py::arg("surfaceProps"), py::arg("releaseProc") = nullptr, py::arg("releaseContext") = nullptr)
+        py::arg("surfaceProps") = nullptr)
     .def_static("MakeFromBackendRenderTarget",
         [] (GrRecordingContext* context, const GrBackendRenderTarget& target,
             GrSurfaceOrigin origin, SkColorType colorType,
@@ -1167,7 +1165,7 @@ surface
             nullptr
         )docstring",
         py::arg("context"), py::arg("budgeted"), py::arg("imageInfo"),
-        py::arg("sampleCount"), py::arg("surfaceProps"))
+        py::arg("sampleCount"), py::arg("surfaceProps") = nullptr)
     .def_static("MakeRenderTarget",
         py::overload_cast<GrRecordingContext*, skgpu::Budgeted, const SkImageInfo&>(
             &SkSurfaces::RenderTarget),

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -717,6 +717,8 @@ surface
         :return: LCD striping orientation and setting for device independent
             fonts
         )docstring")
+/* m117: Remove legacy SkImage and SkSurface methods */
+/*
     .def("flushAndSubmit",
         py::overload_cast<bool>(&SkSurface::flushAndSubmit),
         R"docstring(
@@ -734,7 +736,7 @@ surface
         )docstring",
         py::arg("syncCpu") = false)
     .def("flush",
-        py::overload_cast<SkSurface::BackendSurfaceAccess, const GrFlushInfo&>(
+        py::overload_cast<SkSurfaces::BackendSurfaceAccess, const GrFlushInfo&>(
             &SkSurface::flush),
         R"docstring(
         Issues pending :py:class:`Surface` commands to the GPU-backed API
@@ -850,6 +852,7 @@ surface
         :param newState: optional state change request after flush
         )docstring",
         py::arg("info"), py::arg("newState") = nullptr)
+*/
     .def("characterize", &SkSurface::characterize,
         R"docstring(
         Initializes :py:class:`SurfaceCharacterization` that can be used to

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
-#include <include/core/SkSurfaceCharacterization.h>
 #include <include/core/SkSurfaceProps.h>
+#include <include/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <include/private/chromium/GrSurfaceCharacterization.h>
 #include <include/gpu/GpuTypes.h>
 #include <include/gpu/ganesh/SkSurfaceGanesh.h>
 #include <include/gpu/GrBackendSurfaceMutableState.h>
@@ -91,37 +92,37 @@ surfaceprops
         )docstring")
     ;
 
-py::class_<SkSurfaceCharacterization>(m, "SurfaceCharacterization")
+py::class_<GrSurfaceCharacterization>(m, "SurfaceCharacterization")
     .def(py::init())
-    .def("createResized", &SkSurfaceCharacterization::createResized,
+    .def("createResized", &GrSurfaceCharacterization::createResized,
         py::arg("width"), py::arg("height"))
-    .def("createColorSpace", &SkSurfaceCharacterization::createColorSpace,
+    .def("createColorSpace", &GrSurfaceCharacterization::createColorSpace,
         py::arg("cs"))
-    .def("createBackendFormat", &SkSurfaceCharacterization::createBackendFormat,
+    .def("createBackendFormat", &GrSurfaceCharacterization::createBackendFormat,
         py::arg("colorType"), py::arg("backendFormat"))
-    .def("createFBO0", &SkSurfaceCharacterization::createFBO0,
+    .def("createFBO0", &GrSurfaceCharacterization::createFBO0,
         py::arg("usesGLFBO0"))
     .def(py::self == py::self)
     .def(py::self != py::self)
     .def("cacheMaxResourceBytes",
-        &SkSurfaceCharacterization::cacheMaxResourceBytes)
-    .def("isValid", &SkSurfaceCharacterization::isValid)
-    .def("width", &SkSurfaceCharacterization::width)
-    .def("height", &SkSurfaceCharacterization::height)
+        &GrSurfaceCharacterization::cacheMaxResourceBytes)
+    .def("isValid", &GrSurfaceCharacterization::isValid)
+    .def("width", &GrSurfaceCharacterization::width)
+    .def("height", &GrSurfaceCharacterization::height)
 /*
     #if !SK_SUPPORT_GPU
-    .def("stencilCount", &SkSurfaceCharacterization::stencilCount)
+    .def("stencilCount", &GrSurfaceCharacterization::stencilCount)
     #endif
 */
-    .def("isTextureable", &SkSurfaceCharacterization::isTextureable)
-    .def("isMipMapped", &SkSurfaceCharacterization::isMipMapped)
-    .def("usesGLFBO0", &SkSurfaceCharacterization::usesGLFBO0)
+    .def("isTextureable", &GrSurfaceCharacterization::isTextureable)
+    .def("isMipMapped", &GrSurfaceCharacterization::isMipMapped)
+    .def("usesGLFBO0", &GrSurfaceCharacterization::usesGLFBO0)
     .def("vulkanSecondaryCBCompatible",
-        &SkSurfaceCharacterization::vulkanSecondaryCBCompatible)
-    .def("colorSpace", &SkSurfaceCharacterization::colorSpace,
+        &GrSurfaceCharacterization::vulkanSecondaryCBCompatible)
+    .def("colorSpace", &GrSurfaceCharacterization::colorSpace,
         py::return_value_policy::reference_internal)
-    .def("refColorSpace", &SkSurfaceCharacterization::refColorSpace)
-    .def("surfaceProps", &SkSurfaceCharacterization::surfaceProps)
+    .def("refColorSpace", &GrSurfaceCharacterization::refColorSpace)
+    .def("surfaceProps", &GrSurfaceCharacterization::surfaceProps)
     ;
 
 py::class_<SkSurface, sk_sp<SkSurface>, SkRefCnt> surface(
@@ -1173,7 +1174,7 @@ surface
         py::arg("context"), py::arg("budgeted"), py::arg("imageInfo"))
     .def_static("MakeRenderTarget",
         py::overload_cast<GrRecordingContext*,
-        const SkSurfaceCharacterization&, skgpu::Budgeted>(
+        const GrSurfaceCharacterization&, skgpu::Budgeted>(
             &SkSurfaces::RenderTarget),
         R"docstring(
         Returns :py:class:`Surface` on GPU indicated by context that is

--- a/src/skia/TextBlob.cpp
+++ b/src/skia/TextBlob.cpp
@@ -81,11 +81,12 @@ textblob
                 return SkTextBlob::MakeFromText(
                     text.c_str(), text.size(), font, encoding);
             std::vector<SkPoint> pos_(pos.cast<std::vector<SkPoint>>());
-            if (text.size() != pos_.size())
+            int count = font.countText(text.c_str(), text.size(), encoding);
+            if (count != pos_.size())
                 throw py::value_error(
                     py::str(
                         "len(text) = {} does not match len(pos) = {}").format(
-                        text.size(), pos_.size()));
+                        count, pos_.size()));
             return SkTextBlob::MakeFromPosText(
                 text.c_str(), text.size(), &pos_[0], font, encoding);
         }),
@@ -250,10 +251,11 @@ textblob
         [] (const std::string& text, py::iterable xpos,
             SkScalar constY, const SkFont& font, SkTextEncoding encoding) {
             auto xpos_ = xpos.cast<std::vector<SkScalar>>();
-            if (text.size() != xpos_.size()) {
+            int count = font.countText(text.c_str(), text.size(), encoding);
+            if (count != xpos_.size()) {
                 std::stringstream stream;
                 stream << "text and xpos must have the same number of elements "
-                    << "(len(text) = " << text.size() << ", "
+                    << "(len(text) = " << count << ", "
                     << "len(xpos) = " << xpos_.size() << ").";
                 throw py::value_error(stream.str());
             }
@@ -283,7 +285,8 @@ textblob
     .def_static("MakeFromPosText",
         [] (const std::string& text, const std::vector<SkPoint>& pos,
             const SkFont& font, SkTextEncoding encoding) {
-            if (text.size() != pos.size())
+            int count = font.countText(text.c_str(), text.size(), encoding);
+            if (count != pos.size())
                 throw std::runtime_error(
                     "text and pos must have the same number of elements.");
             return SkTextBlob::MakeFromPosText(
@@ -310,7 +313,8 @@ textblob
     .def_static("MakeFromRSXform",
         [] (const std::string& text, const std::vector<SkRSXform>& xform,
             const SkFont& font, SkTextEncoding encoding) {
-            if (text.size() != xform.size())
+            int count = font.countText(text.c_str(), text.size(), encoding);
+            if (count != xform.size())
                 throw std::runtime_error(
                     "text and xform must have the same number of elements.");
             return SkTextBlob::MakeFromRSXform(

--- a/src/skia/main.cpp
+++ b/src/skia/main.cpp
@@ -26,7 +26,8 @@ void initPoint(py::module &);
 void initRect(py::module &);
 void initRefCnt(py::module &);
 void initRegion(py::module &);
-void initSamplingOptions(py::module&);
+void initSamplingOptions(py::module &);
+void initScalar(py::module &);
 void initSize(py::module &);
 void initStream(py::module &);
 void initString(py::module &);
@@ -68,6 +69,7 @@ PYBIND11_MODULE(skia, m) {
     initPathMeasure(m);
     initPicture(m);
     initPixmap(m);
+    initScalar(m);
     initTextBlob(m);
     initVertices(m);
 

--- a/tests/test_grcontext.py
+++ b/tests/test_grcontext.py
@@ -498,7 +498,6 @@ def test_GrContext_precompileShader(context):
     assert isinstance(context.precompileShader(b'', b''), bool)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_GrContext_ComputeImageSize(image):
     assert isinstance(
         skia.GrContext.ComputeImageSize(image, skia.GrMipmapped.kYes),

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -232,7 +232,6 @@ def test_Image_encodeToData(image, args):
 def test_Image_refEncodedData(image):
     assert isinstance(image.refEncodedData(), skia.Data)
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Image_makeSubset(image):
     assert isinstance(image.makeSubset((10, 10)), skia.Image)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -178,7 +178,6 @@ def test_Image_isValid(image):
     assert isinstance(image.isValid(), bool)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Image_flush(image, context):
     image.flush(context)
 
@@ -241,7 +240,6 @@ def test_Image_hasMipmaps(image):
 def test_Image_withDefaultMipmaps(context, image):
     assert isinstance(image.withDefaultMipmaps(), (type(None), skia.Image))
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Image_makeTextureImage(image, context):
     assert isinstance(
         image.makeTextureImage(
@@ -365,7 +363,6 @@ def texture(context):
     return backend_texture
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Image_MakeFromTexture(context, texture):
     assert isinstance(
         skia.Image.MakeFromTexture(
@@ -455,7 +452,6 @@ def test_Image_MakeFromPicture(picture):
         (skia.Image, type(None)))
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Imag_MakeBackendTextureFromImage(context, image):
     backendTexture = skia.GrBackendTexture()
     assert isinstance(

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -2,8 +2,7 @@ import skia
 import pytest
 
 
-@pytest.mark.skip(reason='segfault in m116; REVISIT')
-#@pytest.fixture
+@pytest.fixture
 def shader():
     return skia.GradientShader.MakeLinear(
         [skia.Point(0, 0), skia.Point(1, 1)], [0xFFFF00FF, 0xFFFFFF00],
@@ -53,14 +52,12 @@ def test_Shaders_Color(args):
     assert isinstance(skia.Shaders.Color(*args), skia.Shader)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Shaders_Blend(shader):
     assert isinstance(
         skia.Shaders.Blend(skia.BlendMode.kSrc, shader, shader),
         skia.Shader)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Shaders_Lerp(shader):
     assert isinstance(
         skia.Shaders.Lerp(0.5, shader, shader), skia.Shader)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -199,7 +199,6 @@ def test_Surface_MakeRasterN32Premul(args):
     check_surface(skia.Surface.MakeRasterN32Premul(*args))
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Surface_MakeFromBackendTexture(context):
     texture = skia.GrBackendTexture()
     assert isinstance(
@@ -209,7 +208,6 @@ def test_Surface_MakeFromBackendTexture(context):
         (type(None), skia.Surface))
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Surface_MakeFromBackendRenderTarget(context):
     target = skia.GrBackendRenderTarget()
     assert isinstance(

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -114,7 +114,6 @@ def test_Surface_readPixels(surface, args):
     assert isinstance(surface.readPixels(*args), bool)
 
 
-@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_asyncRescaleAndReadPixels(surface):
     info = skia.ImageInfo.MakeN32Premul(100, 100)
     def assert_result(result):
@@ -147,12 +146,10 @@ def test_Surface_props(surface):
     assert isinstance(surface.props(), skia.SurfaceProps)
 
 
-@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_flushAndSubmit(surface):
     surface.flushAndSubmit()
 
 
-@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_flush(surface):
     surface.flush(skia.Surface.kNoAccess, skia.GrFlushInfo())
 

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -114,6 +114,7 @@ def test_Surface_readPixels(surface, args):
     assert isinstance(surface.readPixels(*args), bool)
 
 
+@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_asyncRescaleAndReadPixels(surface):
     info = skia.ImageInfo.MakeN32Premul(100, 100)
     def assert_result(result):
@@ -146,10 +147,12 @@ def test_Surface_props(surface):
     assert isinstance(surface.props(), skia.SurfaceProps)
 
 
+@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_flushAndSubmit(surface):
     surface.flushAndSubmit()
 
 
+@pytest.mark.xfail(reason='m117: Remove legacy SkImage and SkSurface methods; may need REVISIT for emulation/no-op stub')
 def test_Surface_flush(surface):
     surface.flush(skia.Surface.kNoAccess, skia.GrFlushInfo())
 


### PR DESCRIPTION
As the name says. M117 is out. The changes are relatively small and "obvious" (compared to m87 to m116...). The most worrying aspect is that surface.flushandsubmit and surface.flush are gone. I don't know if something else needs to be done. But I would recommend NOT merging this until that's investigated.

Canvas.flush is now emulated - but they actually tell you want to do in the m117 release note. 

Also the aarch64 pre job is now split into two - one compiles 800 files for bundled 3rd party and another for skia proper, about 1200 files. Since worst case is about 5 hours 40 minutes, this split the worst case down to about 2 and 4. (Usually it is more like 1.5 hours and 2.5 hours, to make a total of 4).

Anyway, I am thinking of shifting that either sideway or behind the wheel matrix ie split the wheel matrix into native builds vs qemu builds, and re-order them into native builds, skia 3rd party, skia proper, and qemu builds, docs etc. It is more useful to see the result of native build earlier, for failures.

This should pass CI.

