### PR TITLE
M121 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             skia
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m120-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m120-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m121-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m121-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Build skia 3rd-Party

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://kyamagu.github.io/skia-python
 
 - For information about changes after `m116`, and tips on migration from `m87`: [README.m116](relnotes/README.m116.md),
   [README.m117](relnotes/README.m117.md), [README.m118](relnotes/README.m118.md), [README.m119](relnotes/README.m119.md),
-  [README.m120](relnotes/README.m120.md).
+  [README.m120](relnotes/README.m120.md), [README.m121](relnotes/README.m121.md).
 
 ## Contributing
 

--- a/patch/skia-m121-colrv1-freetype.diff
+++ b/patch/skia-m121-colrv1-freetype.diff
@@ -1,0 +1,236 @@
+diff --git a/modules/canvaskit/canvaskit_bindings.cpp b/modules/canvaskit/canvaskit_bindings.cpp
+index 073f853..17b70e3 100644
+--- a/modules/canvaskit/canvaskit_bindings.cpp
++++ b/modules/canvaskit/canvaskit_bindings.cpp
+@@ -110,6 +110,8 @@
+ #include "include/core/SkFontMetrics.h"
+ #include "include/core/SkFontMgr.h"
+ #include "include/core/SkFontTypes.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #ifdef CK_INCLUDE_PARAGRAPH
+ #include "modules/skparagraph/include/Paragraph.h"
+diff --git a/modules/canvaskit/skottie_bindings.cpp b/modules/canvaskit/skottie_bindings.cpp
+index d345fe8..dc8bde8 100644
+--- a/modules/canvaskit/skottie_bindings.cpp
++++ b/modules/canvaskit/skottie_bindings.cpp
+@@ -19,6 +19,8 @@
+ #include "modules/sksg/include/SkSGInvalidationController.h"
+ #include "modules/skunicode/include/SkUnicode.h"
+ #include "src/base/SkUTF.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #include "tools/skui/InputState.h"
+ #include "tools/skui/ModifierKey.h"
+diff --git a/modules/skparagraph/utils/TestFontCollection.cpp b/modules/skparagraph/utils/TestFontCollection.cpp
+index 9e5374f..b796d7d 100644
+--- a/modules/skparagraph/utils/TestFontCollection.cpp
++++ b/modules/skparagraph/utils/TestFontCollection.cpp
+@@ -8,6 +8,8 @@
+ #include "tools/Resources.h"
+ 
+ #if defined(SK_TYPEFACE_FACTORY_FREETYPE)
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #elif defined(SK_TYPEFACE_FACTORY_CORETEXT)
+ #include "src/ports/SkTypeface_mac_ct.h"
+diff --git a/src/core/SkTypeface.cpp b/src/core/SkTypeface.cpp
+index f2d0927..bf2666c 100644
+--- a/src/core/SkTypeface.cpp
++++ b/src/core/SkTypeface.cpp
+@@ -31,6 +31,8 @@
+ #include "src/sfnt/SkOTTable_OS_2.h"
+ 
+ #ifdef SK_TYPEFACE_FACTORY_FREETYPE
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #endif
+ 
+diff --git a/src/ports/SkFontConfigTypeface.h b/src/ports/SkFontConfigTypeface.h
+index 7955049..8551cf7 100644
+--- a/src/ports/SkFontConfigTypeface.h
++++ b/src/ports/SkFontConfigTypeface.h
+@@ -12,6 +12,8 @@
+ #include "include/core/SkStream.h"
+ #include "include/ports/SkFontConfigInterface.h"
+ #include "src/core/SkFontDescriptor.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ 
+ class SkFontDescriptor;
+diff --git a/src/ports/SkFontHost_FreeType.cpp b/src/ports/SkFontHost_FreeType.cpp
+index 1122283..9b196ca 100644
+--- a/src/ports/SkFontHost_FreeType.cpp
++++ b/src/ports/SkFontHost_FreeType.cpp
+@@ -31,7 +31,6 @@
+ #include "src/core/SkMask.h"
+ #include "src/core/SkMaskGamma.h"
+ #include "src/core/SkScalerContext.h"
+-#include "src/ports/SkFontHost_FreeType_common.h"
+ #include "src/sfnt/SkOTUtils.h"
+ #include "src/sfnt/SkSFNTHeader.h"
+ #include "src/sfnt/SkTTCFHeader.h"
+@@ -49,6 +48,7 @@
+ #ifdef FT_COLOR_H  // 2.10.0
+ #   include <freetype/ftcolor.h>
+ #endif
++#include "src/ports/SkFontHost_FreeType_common.h"
+ #include <freetype/freetype.h>
+ #include <freetype/ftlcdfil.h>
+ #include <freetype/ftmodapi.h>
+diff --git a/src/ports/SkFontHost_FreeType_common.cpp b/src/ports/SkFontHost_FreeType_common.cpp
+index 1505cd0..7873a9e 100644
+--- a/src/ports/SkFontHost_FreeType_common.cpp
++++ b/src/ports/SkFontHost_FreeType_common.cpp
+@@ -6,7 +6,6 @@
+  * found in the LICENSE file.
+  */
+ 
+-#include "src/ports/SkFontHost_FreeType_common.h"
+ 
+ #include "include/core/SkBitmap.h"
+ #include "include/core/SkCanvas.h"
+@@ -32,6 +31,7 @@
+ #ifdef FT_COLOR_H
+ #   include <freetype/ftcolor.h>
+ #endif
++#include "src/ports/SkFontHost_FreeType_common.h"
+ #include <freetype/ftimage.h>
+ #include <freetype/ftoutln.h>
+ #include <freetype/ftsizes.h>
+@@ -1577,6 +1577,41 @@ bool SkScalerContext_FreeType_Base::drawCOLRv1Glyph(FT_Face face,
+     SkASSERTF(haveLayers, "Could not get COLRv1 layers from '%s'.", face->family_name);
+     return haveLayers;
+ }
++/*
++ * This content is mostly just
++ *       SkTypeface_FreeType::FaceRec::setupPalette()
++ +     + SkScalerContext_FreeType_Base::drawCOLRv1Glyph()
++ +*/
++bool SkScalerContext_FreeType_Base::skia_colrv1_start_glyph(SkCanvas* canvas,
++                                    FT_Face face,
++                                    uint16_t glyphId,
++                                    FT_UShort palette_index,
++                                    FT_Color_Root_Transform rootTransform
++                                    ) {
++    uint32_t fForegroundColor{SK_ColorBLACK};
++    FT_Palette_Data paletteData;
++    FT_Palette_Data_Get(face, &paletteData);
++
++    FT_Color* ftPalette = nullptr;
++    FT_Palette_Select(face, palette_index, &ftPalette);
++    std::unique_ptr<SkColor[]> ptr_palette(new SkColor[paletteData.num_palette_entries]);
++    for (int i = 0; i < paletteData.num_palette_entries; ++i) {
++      ptr_palette[i] = SkColorSetARGB(ftPalette[i].alpha,
++                                  ftPalette[i].red,
++                                  ftPalette[i].green,
++                                  ftPalette[i].blue);
++    }
++    SkSpan<SkColor> palette(ptr_palette.get(), paletteData.num_palette_entries);
++
++    VisitedSet activePaints;
++    bool haveLayers =  colrv1_start_glyph(canvas, palette,
++                                          fForegroundColor, // FT_Palette_Get_Foreground_Color?
++                                          face, glyphId,
++                                          FT_COLOR_INCLUDE_ROOT_TRANSFORM,
++                                          &activePaints);
++    SkASSERTF(haveLayers, "Could not get COLRv1 layers from '%s'.", face->family_name);
++    return haveLayers;
++}
+ #endif  // TT_SUPPORT_COLRV1
+ 
+ #ifdef FT_COLOR_H
+diff --git a/src/ports/SkFontHost_FreeType_common.h b/src/ports/SkFontHost_FreeType_common.h
+index 6cba604..92e56af 100644
+--- a/src/ports/SkFontHost_FreeType_common.h
++++ b/src/ports/SkFontHost_FreeType_common.h
+@@ -29,6 +29,7 @@ typedef struct FT_FaceRec_* FT_Face;
+ typedef struct FT_StreamRec_* FT_Stream;
+ typedef signed long FT_Pos;
+ typedef struct FT_BBox_ FT_BBox;
++typedef unsigned short  FT_UShort; /* freetype/fttypes.h */
+ 
+ 
+ #ifdef SK_DEBUG
+@@ -41,7 +42,15 @@ const char* SkTraceFtrGetError(int);
+ #endif
+ 
+ 
+-class SkScalerContext_FreeType_Base : public SkScalerContext {
++class SK_SPI SkScalerContext_FreeType_Base : public SkScalerContext {
++public:
++    static bool computeColrV1GlyphBoundingBox(FT_Face, SkGlyphID, SkRect* bounds);
++    static bool skia_colrv1_start_glyph(SkCanvas* canvas,
++                                        FT_Face face,
++                                        uint16_t glyphId,
++                                        FT_UShort palette_index,
++                                        FT_Color_Root_Transform rootTransform
++                                        );
+ protected:
+     // See http://freetype.sourceforge.net/freetype2/docs/reference/ft2-bitmap_handling.html#FT_Bitmap_Embolden
+     // This value was chosen by eyeballing the result in Firefox and trying to match it.
+@@ -68,7 +77,6 @@ protected:
+      *  configure size, matrix and load glyphs as needed after using this function to restore the
+      *  state of FT_Face.
+      */
+-    static bool computeColrV1GlyphBoundingBox(FT_Face, SkGlyphID, SkRect* bounds);
+ 
+     struct ScalerContextBits {
+         static const constexpr uint32_t COLRv0 = 1;
+diff --git a/src/ports/SkFontMgr_android.cpp b/src/ports/SkFontMgr_android.cpp
+index 8a93a2e..d3743ba 100644
+--- a/src/ports/SkFontMgr_android.cpp
++++ b/src/ports/SkFontMgr_android.cpp
+@@ -23,6 +23,8 @@
+ #include "src/core/SkFontDescriptor.h"
+ #include "src/core/SkOSFile.h"
+ #include "src/core/SkTypefaceCache.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #include "src/ports/SkFontMgr_android_parser.h"
+ 
+diff --git a/src/ports/SkFontMgr_custom.cpp b/src/ports/SkFontMgr_custom.cpp
+index a0c6693..536f1c2 100644
+--- a/src/ports/SkFontMgr_custom.cpp
++++ b/src/ports/SkFontMgr_custom.cpp
+@@ -16,6 +16,8 @@
+ #include "include/private/base/SkTArray.h"
+ #include "include/private/base/SkTemplates.h"
+ #include "src/core/SkFontDescriptor.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ #include "src/ports/SkFontMgr_custom.h"
+ 
+diff --git a/src/ports/SkFontMgr_custom.h b/src/ports/SkFontMgr_custom.h
+index 0de4d1d..b9298dd 100644
+--- a/src/ports/SkFontMgr_custom.h
++++ b/src/ports/SkFontMgr_custom.h
+@@ -14,6 +14,8 @@
+ #include "include/core/SkString.h"
+ #include "include/core/SkTypes.h"
+ #include "include/private/base/SkTArray.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ 
+ class SkData;
+diff --git a/src/ports/SkFontMgr_fontconfig.cpp b/src/ports/SkFontMgr_fontconfig.cpp
+index 12b1e95..6d386d9 100644
+--- a/src/ports/SkFontMgr_fontconfig.cpp
++++ b/src/ports/SkFontMgr_fontconfig.cpp
+@@ -28,6 +28,8 @@
+ #include "src/core/SkOSFile.h"
+ #include "src/core/SkScalerContext.h"
+ #include "src/core/SkTypefaceCache.h"
++enum class FT_Color_Root_Transform_;
++typedef FT_Color_Root_Transform_ FT_Color_Root_Transform; /* freetype/ftcolor.h */
+ #include "src/ports/SkFontHost_FreeType_common.h"
+ 
+ #include <fontconfig/fontconfig.h>

--- a/patch/skia-m121-minimize-download.patch
+++ b/patch/skia-m121-minimize-download.patch
@@ -1,0 +1,70 @@
+diff --git a/DEPS b/DEPS
+index 3556177..e9a5c4a 100644
+--- a/DEPS
++++ b/DEPS
+@@ -23,53 +23,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@fb6b960c0a737d20e9b6907a8da56343fd1fab08",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@7ce5da31c2af7a4461e185117c8ae4799e37d29e",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@515dd10de9bf63040045902a4a310d2ba25213a0",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@006709ba3ed87660a17bd4548c45663628f5ed85",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@cb436cf0142b4cbe47aae94223443df7f82e2920",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@45903920b984540bb629bc89f4c010159c23a89a",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@4cfc6d8e173e800df086d7be078da2e8c5cfca19",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@4f81635489681ecf7707623177123cb78d6a66a0",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@ed683925e4897a84b3bffc5c1414c85b97a129a3",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@386707c6d19b974ca2e3db7f5c61873813c6fe44",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@2af26267cdfcb63a88e5c74a85927a12d6ca1d76",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/sfntly"                 : "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git@b55ff303ea2f9e26702b514cf6a3196a2e3e2974",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@4befa3ada54ce2fbdadb2383712da70811efe85e",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@26e8d593e8b8a850722b78ac508cdb4a49a54595",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@a3da0e87fa1a6aacdf32c5e729a653b60afe82af",
+-  "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@cca08c63cefa129d082abca0302adcb81610b465",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@0d87845532579ec3787165cc55635c95180463e0",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@ee3a076b291d206c361431cc841407adf265c692",
+   "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@19a863ccce773ff393b186329478b1eb1a519fd3",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@8718f7f80506b4377d1a37608b532c7c3c54c685",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@2feac587338c7e1b631b2ef9bd6e894d7ad7f56d",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@c876c8f87101c5a75f6014b0f832499afeb65b73",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/relnotes/README.m120.md
+++ b/relnotes/README.m120.md
@@ -3,7 +3,7 @@ New in m120:
 * Rudimentary support (TextBlob::MakeFromShapedText) of text-shaping via
   upstream's libSkShaper module. Intially this was added to support
   emoji's with skin-tone modifiers (#195), but has the fortunate side-effect
-  that now LTR languages (Arabic, Hebrew, Tibetan ...) work as desired in
+  that now RTL languages (Arabic, Hebrew, Tibetan ...) work as desired in
   skia-python's drawing. Note libSkShaper is buggy on windows.
   ( https://issues.skia.org/issues/310510988 )
 

--- a/relnotes/README.m121.md
+++ b/relnotes/README.m121.md
@@ -15,3 +15,5 @@ Since m120:
   should switch to use 'Typeface("")' to suppress the warning. Both Typeface() and
   Typeface.MakeDefault(), the no-argument forms, are likely to be removed in the future.
 
+  Also avoid skia.Font(); e.g. skia.Font(skia.Typeface('Roman')) should be used.
+

--- a/relnotes/README.m121.md
+++ b/relnotes/README.m121.md
@@ -15,5 +15,5 @@ Since m120:
   should switch to use 'Typeface("")' to suppress the warning. Both Typeface() and
   Typeface.MakeDefault(), the no-argument forms, are likely to be removed in the future.
 
-  Also avoid skia.Font(); e.g. skia.Font(skia.Typeface('Roman')) should be used.
+  Also avoid skia.Font() and skia.Font(None, ...) ; e.g. skia.Font(skia.Typeface('')) should be used.
 

--- a/relnotes/README.m121.md
+++ b/relnotes/README.m121.md
@@ -1,0 +1,17 @@
+New in m121:
+
+* Typeface.MakeEmpty() returns a non-null typeface which contains no glyphs. See also Typeface()
+  item below.
+
+Since m120:
+
+* ColorFilters.Compose() re-enabled (likely accidentally disabled in m87->m116)
+
+* TableColorFilter.MakeARGB() now emulated (was removed upstream in m116)
+
+* Typeface() and Typeface.MakeDefault() now emit a Deprecation Warning as upstream deprecates
+  "default typeface". Explicit font family, style or font file choices are recommended. If users
+  really want "any font with visible glyphs" (instead of Typeface.MakeEmpty()), they probably
+  should switch to use 'Typeface("")' to suppress the warning. Both Typeface() and
+  Typeface.MakeDefault(), the no-argument forms, are likely to be removed in the future.
+

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -60,8 +60,8 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m120-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \
     bin/gn gen out/Release --args="

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,8 +4,8 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m120-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='
 is_official_build=true

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,8 +22,8 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m120-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m116-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="
 is_official_build=true

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '120.0b5'
+__version__ = '121.0b5'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '121.0b5'
+__version__ = '121.0b6'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/ColorFilter.cpp
+++ b/src/skia/ColorFilter.cpp
@@ -135,7 +135,6 @@ py::class_<SkColorMatrix>(m, "ColorMatrix")
     ;
 
 py::class_<SkColorFilters>(m, "ColorFilters")
-/*
     .def_static("Compose",
         [] (const SkColorFilter& outer, const SkColorFilter& inner) {
             return SkColorFilters::Compose(
@@ -143,7 +142,6 @@ py::class_<SkColorFilters>(m, "ColorFilters")
                 CloneFlattenable<SkColorFilter>(inner));
         },
         py::arg("outer"), py::arg("inner"))
-*/
     .def_static("Blend", py::overload_cast<const SkColor4f&, sk_sp<SkColorSpace>,
         SkBlendMode>(&SkColorFilters::Blend),
         py::arg("c"), py::arg("colorspace"), py::arg("mode"))

--- a/src/skia/ColorFilter.cpp
+++ b/src/skia/ColorFilter.cpp
@@ -298,7 +298,6 @@ py::class_<std::unique_ptr<uint8_t>>(
         applied, and then the result is remultiplied.
         )docstring",
         py::arg("table"))
-/*
     .def_static("MakeARGB",
         [] (py::object tableA, py::object tableR, py::object tableG,
             py::object tableB) {
@@ -307,7 +306,7 @@ py::class_<std::unique_ptr<uint8_t>>(
             CopyTableIfValid(tableR, &tableR_);
             CopyTableIfValid(tableG, &tableG_);
             CopyTableIfValid(tableB, &tableB_);
-            return SkTableColorFilter::MakeARGB(
+            return SkColorFilters::TableARGB(
                 (tableA_.empty()) ? nullptr : &tableA_[0],
                 (tableR_.empty()) ? nullptr : &tableR_[0],
                 (tableG_.empty()) ? nullptr : &tableG_[0],
@@ -323,7 +322,6 @@ py::class_<std::unique_ptr<uint8_t>>(
         )docstring",
         py::arg("tableA"), py::arg("tableR"), py::arg("tableG"),
         py::arg("tableB"))
-*/
     ;
 
 }

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -558,6 +558,11 @@ typeface
     .def("__eq__", &SkTypeface::Equal, py::is_operator())
     .def_static("MakeDefault",
         [] (void) {
+            auto warnings = pybind11::module::import("warnings");
+            auto builtins = pybind11::module::import("builtins");
+            warnings.attr("warn")(
+                "\"Default typeface\" is deprecated upstream. Please specify name/file/style choices.",
+                builtins.attr("DeprecationWarning"));
             return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle());
         },
         R"docstring(

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -259,7 +259,15 @@ py::enum_<SkTypeface::SerializeBehavior>(typeface, "SerializeBehavior",
     .export_values();
 
 typeface
-    .def(py::init([] () { return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()); }),
+    .def(py::init(
+        [] (void) {
+            auto warnings = pybind11::module::import("warnings");
+            auto builtins = pybind11::module::import("builtins");
+            warnings.attr("warn")(
+                "\"Default typeface\" is deprecated upstream. Please specify name/file/style choices.",
+                builtins.attr("DeprecationWarning"));
+            return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle());
+        }),
         R"docstring(
         Returns the default normal typeface.
         )docstring")

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -259,9 +259,9 @@ py::enum_<SkTypeface::SerializeBehavior>(typeface, "SerializeBehavior",
     .export_values();
 
 typeface
-    .def(py::init([] () { return SkTypeface::MakeEmpty(); }),
+    .def(py::init([] () { return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()); }),
         R"docstring(
-        Returns a non-null typeface which contains no glyphs.
+        Returns the default normal typeface.
         )docstring")
     .def(py::init(&SkTypeface_MakeFromName),
         R"docstring(
@@ -556,7 +556,14 @@ typeface
         )docstring",
         py::arg("self"), py::arg("other"))
     .def("__eq__", &SkTypeface::Equal, py::is_operator())
-    .def_static("MakeDefault", &SkTypeface::MakeEmpty,
+    .def_static("MakeDefault",
+        [] (void) {
+            return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle());
+        },
+        R"docstring(
+        Returns the default normal typeface, which is never nullptr.
+        )docstring")
+    .def_static("MakeEmpty", &SkTypeface::MakeEmpty,
         R"docstring(
         Returns a non-null typeface which contains no glyphs.
         )docstring")

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -807,11 +807,31 @@ font
                 self.getSkewX());
         })
 */
-    .def(py::init<>(),
+    .def(py::init(
+        [] (void) {
+            auto warnings = pybind11::module::import("warnings");
+            auto builtins = pybind11::module::import("builtins");
+            warnings.attr("warn")(
+                "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
+                builtins.attr("DeprecationWarning"));
+            return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()));
+        }),
         R"docstring(
         Constructs :py:class:`Font` with default values.
         )docstring")
-    .def(py::init<sk_sp<SkTypeface>, SkScalar>(),
+    .def(py::init(
+        [] (py::object typeface, SkScalar size) {
+            if (typeface.is_none()) {
+                auto warnings = pybind11::module::import("warnings");
+                auto builtins = pybind11::module::import("builtins");
+                warnings.attr("warn")(
+                    "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
+                    builtins.attr("DeprecationWarning"));
+                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()), size);
+            } else {
+                return SkFont(typeface.cast<sk_sp<SkTypeface>>(), size);
+            }
+        }),
         R"docstring(
         Constructs :py:class:`Font` with default values with
         :py:class:`Typeface` and size in points.
@@ -821,7 +841,19 @@ font
         :size: typographic height of text
         )docstring",
         py::arg("typeface"), py::arg("size"))
-    .def(py::init<sk_sp<SkTypeface>>(),
+    .def(py::init(
+        [] (py::object typeface) {
+            if (typeface.is_none()) {
+                auto warnings = pybind11::module::import("warnings");
+                auto builtins = pybind11::module::import("builtins");
+                warnings.attr("warn")(
+                    "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
+                    builtins.attr("DeprecationWarning"));
+                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()));
+            } else {
+                return SkFont(typeface.cast<sk_sp<SkTypeface>>());
+            }
+        }),
         R"docstring(
         Constructs :py:class:`Font` with default values with
         :py:class:`Typeface`.
@@ -830,7 +862,21 @@ font
             text
         )docstring",
         py::arg("typeface"))
-    .def(py::init<sk_sp<SkTypeface>, SkScalar, SkScalar, SkScalar>(),
+    .def(py::init(
+        [] (py::object typeface, SkScalar size, SkScalar scaleX, SkScalar skewX) {
+            if (typeface.is_none()) {
+                auto warnings = pybind11::module::import("warnings");
+                auto builtins = pybind11::module::import("builtins");
+                warnings.attr("warn")(
+                    "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
+                    builtins.attr("DeprecationWarning"));
+                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()),
+                                      size, scaleX, skewX);
+            } else {
+                return SkFont(typeface.cast<sk_sp<SkTypeface>>(),
+                                      size, scaleX, skewX);
+            }
+        }),
         R"docstring(
         Constructs :py:class:`Font` with default values with
         :py:class:`Typeface` and size in points, horizontal scale, and

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -259,9 +259,9 @@ py::enum_<SkTypeface::SerializeBehavior>(typeface, "SerializeBehavior",
     .export_values();
 
 typeface
-    .def(py::init([] () { return SkTypeface::MakeDefault(); }),
+    .def(py::init([] () { return SkTypeface::MakeEmpty(); }),
         R"docstring(
-        Returns the default normal typeface.
+        Returns a non-null typeface which contains no glyphs.
         )docstring")
     .def(py::init(&SkTypeface_MakeFromName),
         R"docstring(
@@ -556,9 +556,9 @@ typeface
         )docstring",
         py::arg("self"), py::arg("other"))
     .def("__eq__", &SkTypeface::Equal, py::is_operator())
-    .def_static("MakeDefault", &SkTypeface::MakeDefault,
+    .def_static("MakeDefault", &SkTypeface::MakeEmpty,
         R"docstring(
-        Returns the default normal typeface, which is never nullptr.
+        Returns a non-null typeface which contains no glyphs.
         )docstring")
     .def_static("MakeFromName", &SkTypeface_MakeFromName,
         R"docstring(

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -58,13 +58,13 @@ py::enum_<skgpu::BackendApi>(m, "gpuBackendApi",
     .value("kMock", skgpu::BackendApi::kMock)
     .export_values();
 
-py::enum_<GrMipmapped>(m, "GrMipmapped",
+py::enum_<skgpu::Mipmapped>(m, "skgpu::Mipmapped",
     R"docstring(
     Used to say whether a texture has mip levels allocated or not.
     )docstring",
     py::arithmetic())
-    .value("kNo", GrMipmapped::kNo)
-    .value("kYes", GrMipmapped::kYes)
+    .value("kNo", skgpu::Mipmapped::kNo)
+    .value("kYes", skgpu::Mipmapped::kYes)
     .export_values();
 
 py::enum_<GrRenderable>(m, "GrRenderable", py::arithmetic())
@@ -316,7 +316,7 @@ py::class_<GrBackendTexture>(m, "GrBackendTexture")
         }),
         py::arg("width"), py::arg("height"), py::arg("vkInfo"))
 #endif
-    .def(py::init<int, int, GrMipmapped, const GrMockTextureInfo&>(),
+    .def(py::init<int, int, skgpu::Mipmapped, const GrMockTextureInfo&>(),
         py::arg("width"), py::arg("height"), py::arg("mipMapped"),
         py::arg("mockInfo"))
     .def(py::init<const GrBackendTexture&>(), py::arg("that"))
@@ -867,8 +867,8 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("supportsDistanceFieldText", &GrDirectContext::supportsDistanceFieldText)
     .def("storeVkPipelineCacheData", &GrDirectContext::storeVkPipelineCacheData)
     .def_static("ComputeImageSize",
-        [] (sk_sp<SkImage> image, GrMipmapped mapped, bool useNextPow2) {
-            // REVISIT: process GrMipmapped and useNextPow2 = true
+        [] (sk_sp<SkImage> image, skgpu::Mipmapped mapped, bool useNextPow2) {
+            // REVISIT: process skgpu::Mipmapped and useNextPow2 = true
             return image->textureSize();
         },
         py::arg("image"), py::arg("mipMapped"), py::arg("useNextPow2") = false)
@@ -885,7 +885,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
         )docstring",
         py::arg("colorType"), py::arg("renderable") = GrRenderable::kNo)
     .def("createBackendTexture",
-        py::overload_cast<int, int, const GrBackendFormat&, GrMipmapped,
+        py::overload_cast<int, int, const GrBackendFormat&, skgpu::Mipmapped,
             GrRenderable, GrProtected, std::string_view>(&GrDirectContext::createBackendTexture),
         R"docstring(
         If possible, create an uninitialized backend texture.
@@ -898,7 +898,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
         py::arg("mipMapped"), py::arg("renderable"),
         py::arg("isProtected") = GrProtected::kNo, py::arg("view") = std::string_view{})
     .def("createBackendTexture",
-        py::overload_cast<int, int, SkColorType, GrMipmapped,
+        py::overload_cast<int, int, SkColorType, skgpu::Mipmapped,
             GrRenderable, GrProtected, std::string_view>(&GrDirectContext::createBackendTexture),
         R"docstring(
         If possible, create an uninitialized backend texture.
@@ -914,7 +914,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             const GrBackendFormat& backendFormat, const SkColor4f& color,
-            GrMipmapped mipMapped, GrRenderable renderable,
+            skgpu::Mipmapped mipMapped, GrRenderable renderable,
             GrProtected isProtected) {
             return context.createBackendTexture(
                 width, height, backendFormat, color, mipMapped, renderable,
@@ -938,7 +938,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             SkColorType colorType, const SkColor4f& color,
-            GrMipmapped mipMapped, GrRenderable renderable,
+            skgpu::Mipmapped mipMapped, GrRenderable renderable,
             GrProtected isProtected) {
             return context.createBackendTexture(
                 width, height, colorType, color, mipMapped, renderable,
@@ -1058,7 +1058,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createCompressedBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             const GrBackendFormat& backendFormat, const SkColor4f& color,
-            GrMipmapped mipMapped, GrProtected isProtected) {
+            skgpu::Mipmapped mipMapped, GrProtected isProtected) {
             return context.createCompressedBackendTexture(
                 width, height, backendFormat, color, mipMapped, isProtected);
         },
@@ -1076,7 +1076,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createCompressedBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             SkTextureCompressionType type, const SkColor4f& color,
-            GrMipmapped mipMapped, GrProtected isProtected) {
+            skgpu::Mipmapped mipMapped, GrProtected isProtected) {
             return context.createCompressedBackendTexture(
                 width, height, type, color, mipMapped, isProtected);
         },
@@ -1085,7 +1085,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createCompressedBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             const GrBackendFormat& backendFormat, py::buffer b,
-            GrMipmapped mipMapped, GrProtected isProtected) {
+            skgpu::Mipmapped mipMapped, GrProtected isProtected) {
             auto info = b.request();
             size_t size = (info.ndim) ? info.strides[0] * info.shape[0] : 0;
             return context.createCompressedBackendTexture(
@@ -1098,7 +1098,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     .def("createCompressedBackendTexture",
         [] (GrDirectContext& context, int width, int height,
             SkTextureCompressionType type, py::buffer b,
-            GrMipmapped mipMapped, GrProtected isProtected) {
+            skgpu::Mipmapped mipMapped, GrProtected isProtected) {
             auto info = b.request();
             size_t size = (info.ndim) ? info.strides[0] * info.shape[0] : 0;
             return context.createCompressedBackendTexture(

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -58,7 +58,7 @@ py::enum_<skgpu::BackendApi>(m, "gpuBackendApi",
     .value("kMock", skgpu::BackendApi::kMock)
     .export_values();
 
-py::enum_<skgpu::Mipmapped>(m, "skgpu::Mipmapped",
+py::enum_<skgpu::Mipmapped>(m, "GrMipmapped",
     R"docstring(
     Used to say whether a texture has mip levels allocated or not.
     )docstring",

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -650,7 +650,7 @@ image
         :param int width: width of full :py:class:`Image`
         :param int height: height of full :py:class:`Image`
         :param skia.CompressionType type: type of compression used
-        :param skia.GrMipmapped mipMapped: does 'data' contain data for all the
+        :param skia.skgpu::Mipmapped mipMapped: does 'data' contain data for all the
             mipmap levels?
         :param skia.GrProtected isProtected: do the contents of 'data' require
             DRM protection (on Vulkan)?
@@ -658,7 +658,7 @@ image
         )docstring",
         py::arg("context"), py::arg("data"), py::arg("width"),
         py::arg("height"), py::arg("type"),
-        py::arg("mipMapped") = GrMipmapped::kNo,
+        py::arg("mipMapped") = skgpu::Mipmapped::kNo,
         py::arg("isProtected") = GrProtected::kNo)
     .def_static("MakeRasterFromCompressed", &SkImages::RasterFromCompressedTextureData,
         R"docstring(
@@ -957,7 +957,7 @@ image
     .def_static("MakeFromYUVAPixmaps",
         [] (GrRecordingContext* context,
             const SkYUVAPixmaps& pixmaps,
-            GrMipMapped buildMips,
+            skgpu::Mipmapped buildMips,
             bool limitToMaxTextureSize,
             const SkColorSpace* imageColorSpace) {
             return SkImages::TextureFromYUVAPixmaps(
@@ -997,7 +997,7 @@ image
         :return:                      created :py:class:`Image`, or nullptr
         )docstring",
         py::arg("context"), py::arg("pixmaps"),
-        py::arg("buildMips") = GrMipmapped::kNo,
+        py::arg("buildMips") = skgpu::Mipmapped::kNo,
         py::arg("limitToMaxTextureSize") = false,
         py::arg("imageColorSpace") = nullptr)
 /*
@@ -1626,7 +1626,7 @@ image
 
         Returned :py:class:`Image` is compatible with :py:class:`Surface`
         created with dstColorSpace. The returned :py:class:`Image` respects
-        mipMapped setting; if mipMapped equals :py:attr:`GrMipmapped.kYes`, the
+        mipMapped setting; if mipMapped equals :py:attr:`skgpu::Mipmapped.kYes`, the
         backing texture allocates mip map levels.
 
         The mipMapped parameter is effectively treated as kNo if MIP maps are
@@ -1641,13 +1641,13 @@ image
 
         :param GrDirectContext context: the GrDirectContext in play, if it
             exists
-        :param GrMipmapped mipMapped: whether created :py:class:`Image` texture
+        :param skgpu::Mipmapped mipMapped: whether created :py:class:`Image` texture
             must allocate mip map levels
         :param skia.Budgeted budgeted: whether to count a newly created texture
             for the returned image counts against the GrDirectContext's budget.
         :return: created :py:class:`Image`, or nullptr
         )docstring",
-        py::arg("context").none(false), py::arg("mipMapped") = GrMipmapped::kNo,
+        py::arg("context").none(false), py::arg("mipMapped") = skgpu::Mipmapped::kNo,
         py::arg("budgeted") = skgpu::Budgeted::kYes)
     .def("makeNonTextureImage", &SkImage::makeNonTextureImage,
         R"docstring(

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -24,7 +24,9 @@ void PyReadPixelsCallback (
 }  // namespace
 
 
+/*
 const SkSurfaceProps::Flags SkSurfaceProps::kUseDistanceFieldFonts_Flag;
+*/
 
 void initSurface(py::module &m) {
 
@@ -84,6 +86,7 @@ surfaceprops
         &SkSurfaceProps::isUseDeviceIndependentFonts)
     .def(py::self == py::self)
     .def(py::self != py::self)
+/*
     .def_readonly_static("kUseDistanceFieldFonts_Flag",
         &SkSurfaceProps::kUseDistanceFieldFonts_Flag,
         R"docstring(
@@ -91,6 +94,7 @@ surfaceprops
 
         Will be removed.
         )docstring")
+*/
     ;
 
 py::class_<GrSurfaceCharacterization>(m, "SurfaceCharacterization")

--- a/tests/test_colorfilter.py
+++ b/tests/test_colorfilter.py
@@ -112,6 +112,5 @@ def test_TableColorFilter_Make():
     (range(256), range(256), range(256), range(256)),
     (range(256), None, None, None),
 ])
-@pytest.mark.xfail(reason='TableColorFilter class removed in m116')
 def test_TableColorFilter_MakeARGB(args):
     assert isinstance(skia.TableColorFilter.MakeARGB(*args), skia.ColorFilter)

--- a/tests/test_colorfilter.py
+++ b/tests/test_colorfilter.py
@@ -46,7 +46,6 @@ def test_ColorFilter_Deserialize(colorfilter):
         skia.ColorFilter.Deserialize(colorfilter.serialize()), skia.ColorFilter)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_ColorFilters_Compose(colorfilter):
     assert isinstance(
         skia.ColorFilters.Compose(colorfilter, colorfilter),

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -151,7 +151,6 @@ def test_Typeface_getUnitsPerEm(typeface):
     assert isinstance(typeface.getUnitsPerEm(), int)
 
 
-@pytest.mark.skip(reason='segfault in m116; REVISIT')
 def test_Typeface_getKerningPairAdjustments(typeface):
     assert isinstance(
         typeface.getKerningPairAdjustments([0]), (list, type(None)))

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -389,7 +389,7 @@ def test_FontMgr_ref_unref(fontmgr):
 
 @pytest.fixture(scope='session')
 def font():
-    return skia.Font(skia.Typeface('Roman'))
+    return skia.Font(skia.Typeface(""))
 
 
 @pytest.mark.parametrize('args', [

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -389,7 +389,7 @@ def test_FontMgr_ref_unref(fontmgr):
 
 @pytest.fixture(scope='session')
 def font():
-    return skia.Font()
+    return skia.Font(skia.Typeface('Roman'))
 
 
 @pytest.mark.parametrize('args', [
@@ -571,12 +571,10 @@ def test_Font_getXPos(font, glyphs):
     assert isinstance(font.getXPos(glyphs), list)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Font_getPath(font, glyphs):
     assert isinstance(font.getPath(glyphs[0]), skia.Path)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Font_getPaths(font, glyphs):
     paths = font.getPaths(glyphs)
     assert isinstance(paths, list)

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -10,12 +10,9 @@ def shader():
 
 
 def test_Shader_isOpaque(shader):
-    if (shader == None):
-        pytest.skip("segfault:m116:REVISIT")
     assert isinstance(shader.isOpaque(), bool)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 @pytest.mark.parametrize('args', [
     (skia.Matrix(), [skia.TileMode.kClamp, skia.TileMode.kClamp]),
     tuple(),
@@ -24,18 +21,20 @@ def test_Shader_isAImage(shader, args):
     assert isinstance(shader.isAImage(*args), (bool, type(None), skia.Image))
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
+@pytest.mark.skip(reason='m87->m116:DEPRECATED. skbug.com/8941')
+# DEPRECATED at m87.
+# "asAGradient(GradientInfo* info)" was used only by on Android and
+# moved to include/android/SkAndroidFrameworkUtils.h as
+# "ShaderAsALinearGradient(SkShader* shader, LinearGradientInfo*)".
 def test_Shader_asAGradient(shader):
     info = skia.Shader.GradientInfo()
     assert isinstance(shader.asAGradient(info), skia.Shader.GradientType)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Shader_makeWithLocalMatrix(shader):
     assert isinstance(shader.makeWithLocalMatrix(skia.Matrix()), skia.Shader)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 def test_Shader_makeWithColorFilter(shader):
     assert isinstance(
         shader.makeWithColorFilter(skia.LumaColorFilter.Make()), skia.Shader)
@@ -64,7 +63,6 @@ def test_Shaders_Lerp(shader):
         skia.Shaders.Lerp(0.5, shader, shader), skia.Shader)
 
 
-@pytest.mark.skip(reason='m116:REVISIT')
 @pytest.mark.parametrize('args', [
     ([skia.Point(0, 0), skia.Point(1, 1)], [0xFFFF00FF, 0xFFFFFF00]),
     ([skia.Point(0, 0), skia.Point(1, 1)], [0xFFFF00FF, 0xFFFFFF00], [0, 1],

--- a/tests/test_textblob.py
+++ b/tests/test_textblob.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture
 def textblob():
-    return skia.TextBlob('foo', skia.Font())
+    return skia.TextBlob('foo', skia.Font(skia.Typeface("")))
 
 
 @pytest.mark.parametrize('args', [


### PR DESCRIPTION
The changes are all straight-forward. The font tests pass, but the change of what Typeface.MakeDefault does (from a normal default to empty) as from upstream may need rethinking / emulate properly, or with a large warning in the release notes. It will likely break somebody's code, if they assume MakeDefault will give them Times/Arial/Noto, instead of a font with no glyphs.

Re-think on that.