### PR TITLE
M122 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Build skia bundled 3rd-party on linux/aarch64
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-skia
         with:
           path: |
@@ -26,7 +26,7 @@ jobs:
       - name: Pre-fetch skia deps
         run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m122-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m122-minimize-download.patch
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Build skia 3rd-Party
         # Taken from https://github.com/pypa/cibuildwheel/blob/v2.16.2/cibuildwheel/resources/pinned_docker_images.cfg
         uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-10-03-72cdc42
@@ -41,24 +41,24 @@ jobs:
     needs: prebuild_linux_aarch64_3rd_party
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-skia
         with:
           path: |
             gn
             skia
           key: linux-aarch64-skia-${{ github.sha }}
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         with:
           path: |
             gn
             skia
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Build Skia Proper
         uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-10-03-72cdc42
         with:
@@ -100,11 +100,11 @@ jobs:
             cp: cp312
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         if: runner.os == 'Linux' && matrix.arch == 'aarch64'
         with:
           path: |
@@ -114,7 +114,7 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ matrix.arch }}
 
@@ -144,7 +144,7 @@ jobs:
     needs: [build_wheels]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             skia
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m121-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m121-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m122-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m122-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Build skia 3rd-Party

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"

--- a/patch/skia-m122-colrv1-freetype.diff
+++ b/patch/skia-m122-colrv1-freetype.diff
@@ -1,0 +1,119 @@
+diff --git a/src/ports/SkFontHost_FreeType.cpp b/src/ports/SkFontHost_FreeType.cpp
+index 7e096a6..46fe7a0 100644
+--- a/src/ports/SkFontHost_FreeType.cpp
++++ b/src/ports/SkFontHost_FreeType.cpp
+@@ -33,7 +33,6 @@
+ #include "src/core/SkMask.h"
+ #include "src/core/SkMaskGamma.h"
+ #include "src/core/SkScalerContext.h"
+-#include "src/ports/SkFontHost_FreeType_common.h"
+ #include "src/ports/SkTypeface_FreeType.h"
+ #include "src/sfnt/SkOTUtils.h"
+ #include "src/sfnt/SkSFNTHeader.h"
+@@ -52,6 +51,7 @@
+ #ifdef FT_COLOR_H  // 2.10.0
+ #   include <freetype/ftcolor.h>
+ #endif
++#include "src/ports/SkFontHost_FreeType_common.h"
+ #include <freetype/freetype.h>
+ #include <freetype/ftlcdfil.h>
+ #include <freetype/ftmodapi.h>
+diff --git a/src/ports/SkFontHost_FreeType_common.cpp b/src/ports/SkFontHost_FreeType_common.cpp
+index 14b2adb..f041583 100644
+--- a/src/ports/SkFontHost_FreeType_common.cpp
++++ b/src/ports/SkFontHost_FreeType_common.cpp
+@@ -6,7 +6,6 @@
+  * found in the LICENSE file.
+  */
+ 
+-#include "src/ports/SkFontHost_FreeType_common.h"
+ 
+ #include "include/core/SkBitmap.h"
+ #include "include/core/SkCanvas.h"
+@@ -32,6 +31,7 @@
+ #ifdef FT_COLOR_H
+ #   include <freetype/ftcolor.h>
+ #endif
++#include "src/ports/SkFontHost_FreeType_common.h"
+ #include <freetype/ftimage.h>
+ #include <freetype/ftoutln.h>
+ #include <freetype/ftsizes.h>
+@@ -1574,6 +1574,41 @@ bool SkScalerContext_FreeType_Base::drawCOLRv1Glyph(FT_Face face,
+     SkASSERTF(haveLayers, "Could not get COLRv1 layers from '%s'.", face->family_name);
+     return haveLayers;
+ }
++/*
++ * This content is mostly just
++ *       SkTypeface_FreeType::FaceRec::setupPalette()
++ +     + SkScalerContext_FreeType_Base::drawCOLRv1Glyph()
++ +*/
++bool SkScalerContext_FreeType_Base::skia_colrv1_start_glyph(SkCanvas* canvas,
++                                    FT_Face face,
++                                    uint16_t glyphId,
++                                    FT_UShort palette_index,
++                                    FT_Color_Root_Transform rootTransform
++                                    ) {
++    uint32_t fForegroundColor{SK_ColorBLACK};
++    FT_Palette_Data paletteData;
++    FT_Palette_Data_Get(face, &paletteData);
++
++    FT_Color* ftPalette = nullptr;
++    FT_Palette_Select(face, palette_index, &ftPalette);
++    std::unique_ptr<SkColor[]> ptr_palette(new SkColor[paletteData.num_palette_entries]);
++    for (int i = 0; i < paletteData.num_palette_entries; ++i) {
++      ptr_palette[i] = SkColorSetARGB(ftPalette[i].alpha,
++                                  ftPalette[i].red,
++                                  ftPalette[i].green,
++                                  ftPalette[i].blue);
++    }
++    SkSpan<SkColor> palette(ptr_palette.get(), paletteData.num_palette_entries);
++
++    VisitedSet activePaints;
++    bool haveLayers =  colrv1_start_glyph(canvas, palette,
++                                          fForegroundColor, // FT_Palette_Get_Foreground_Color?
++                                          face, glyphId,
++                                          FT_COLOR_INCLUDE_ROOT_TRANSFORM,
++                                          &activePaints);
++    SkASSERTF(haveLayers, "Could not get COLRv1 layers from '%s'.", face->family_name);
++    return haveLayers;
++}
+ #endif  // TT_SUPPORT_COLRV1
+ 
+ #ifdef FT_COLOR_H
+diff --git a/src/ports/SkFontHost_FreeType_common.h b/src/ports/SkFontHost_FreeType_common.h
+index d649784..1100b0e 100644
+--- a/src/ports/SkFontHost_FreeType_common.h
++++ b/src/ports/SkFontHost_FreeType_common.h
+@@ -19,6 +19,7 @@
+ typedef struct FT_FaceRec_* FT_Face;
+ typedef struct FT_StreamRec_* FT_Stream;
+ typedef signed long FT_Pos;
++typedef unsigned short  FT_UShort; /* freetype/fttypes.h */
+ 
+ 
+ #ifdef SK_DEBUG
+@@ -31,7 +32,15 @@ const char* SkTraceFtrGetError(int);
+ #endif
+ 
+ 
+-class SkScalerContext_FreeType_Base : public SkScalerContext {
++class SK_SPI SkScalerContext_FreeType_Base : public SkScalerContext {
++public:
++    static bool computeColrV1GlyphBoundingBox(FT_Face, SkGlyphID, SkRect* bounds);
++    static bool skia_colrv1_start_glyph(SkCanvas* canvas,
++                                        FT_Face face,
++                                        uint16_t glyphId,
++                                        FT_UShort palette_index,
++                                        FT_Color_Root_Transform rootTransform
++                                        );
+ protected:
+     // See http://freetype.sourceforge.net/freetype2/docs/reference/ft2-bitmap_handling.html#FT_Bitmap_Embolden
+     // This value was chosen by eyeballing the result in Firefox and trying to match it.
+@@ -57,7 +66,6 @@ protected:
+      *  configure size, matrix and load glyphs as needed after using this function to restore the
+      *  state of FT_Face.
+      */
+-    static bool computeColrV1GlyphBoundingBox(FT_Face, SkGlyphID, SkRect* bounds);
+ 
+     struct ScalerContextBits {
+         static const constexpr uint32_t COLRv0 = 1;

--- a/patch/skia-m122-minimize-download.patch
+++ b/patch/skia-m122-minimize-download.patch
@@ -1,0 +1,70 @@
+diff --git a/DEPS b/DEPS
+index bd7ed9d..8180821 100644
+--- a/DEPS
++++ b/DEPS
+@@ -23,53 +23,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@c6fbf93decbac74cd14c6ca3d600d4ed91d1179d",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@5b45794c2c24c3fa40dc480af92c5284a95423ef",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@e2d024354e11cc6b041b0cff032d73f0c7e43a07",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@334aca32051ef6ede2711487acf45d959e9bdffc",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@45903920b984540bb629bc89f4c010159c23a89a",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@4cfc6d8e173e800df086d7be078da2e8c5cfca19",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@4f81635489681ecf7707623177123cb78d6a66a0",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@ed683925e4897a84b3bffc5c1414c85b97a129a3",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@386707c6d19b974ca2e3db7f5c61873813c6fe44",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@2af26267cdfcb63a88e5c74a85927a12d6ca1d76",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/sfntly"                 : "https://chromium.googlesource.com/external/github.com/googlei18n/sfntly.git@b55ff303ea2f9e26702b514cf6a3196a2e3e2974",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@328e794f0c8bddc81c834ccc89c9652902f643cb",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@4307b0183c9e16bc920ef0bceaa9e9d630c352c3",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b82536766d1b81631b126d1ddbe49baf42929bd3",
+-  "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@7b0309708da5126b89e4ce6f19835f36dc912f2f",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@3e6bdd0f99655b1bc6a54aa73e5bfaaa4252198b",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@ee3a076b291d206c361431cc841407adf265c692",
+   "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@217e93c664ec6704ec2d8c36fa116c1a4a1e2d40",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@7c6d640a5ca3ab73c1f42d22312f672b54babfaf",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@4cfc176e3242b4dbdfd3f6c5680c5d8f2cb7db45",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@c876c8f87101c5a75f6014b0f832499afeb65b73",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -60,8 +60,8 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m122-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m122-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \
     bin/gn gen out/Release --args="

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,8 +4,8 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m122-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m122-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='
 is_official_build=true

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,8 +22,8 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m121-minimize-download.patch && \
-    patch -p1 < ../patch/skia-m121-colrv1-freetype.diff && \
+    patch -p1 < ../patch/skia-m122-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m122-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="
 is_official_build=true

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '121.0b6'
+__version__ = '122.0b6'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -15,8 +15,7 @@
 #endif
 
 #ifdef __linux__
-#include "include/ports/SkFontConfigInterface.h"
-#include "include/ports/SkFontMgr_FontConfigInterface.h"
+#include "include/ports/SkFontMgr_fontconfig.h"
 #endif
 
 #ifdef _WIN32
@@ -35,8 +34,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
 #if defined(__apple__)
   return SkFontMgr_New_CoreText(nullptr);
 #elif defined(__linux__)
-  sk_sp<SkFontConfigInterface> fci(SkFontConfigInterface::RefGlobal());
-  return fci ? SkFontMgr_New_FCI(std::move(fci)) : nullptr;
+  return SkFontMgr_New_FontConfig(nullptr);
 #elif defined(_WIN32)
   return SkFontMgr_New_DirectWrite();
 #else

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -10,6 +10,50 @@
 #include <src/ports/SkFontHost_FreeType_common.h>
 #endif
 
+#ifdef __apple__
+#include "include/ports/SkFontMgr_mac_ct.h"
+#endif
+
+#ifdef __linux__
+#include "include/ports/SkFontConfigInterface.h"
+#include "include/ports/SkFontMgr_FontConfigInterface.h"
+#endif
+
+#ifdef _WIN32
+#include "include/ports/SkTypeface_win.h"
+#endif
+
+#include <mutex>
+
+namespace {
+
+bool g_factory_called = false;
+
+}  // namespace
+
+static sk_sp<SkFontMgr> fontmgr_factory() {
+#if defined(__apple__)
+  return SkFontMgr_New_CoreText(nullptr);
+#elif defined(__linux__)
+  sk_sp<SkFontConfigInterface> fci(SkFontConfigInterface::RefGlobal());
+  return fci ? SkFontMgr_New_FCI(std::move(fci)) : nullptr;
+#elif defined(_WIN32)
+  return SkFontMgr_New_DirectWrite();
+#else
+  return SkFontMgr_New_Custom_Empty(); /* last resort: SkFontMgr::RefEmpty(); */
+#endif
+}
+
+sk_sp<SkFontMgr> SkFontMgr_RefDefault() {
+  static std::once_flag flag;
+  static sk_sp<SkFontMgr> mgr;
+  std::call_once(flag, [] {
+    mgr = fontmgr_factory();
+    g_factory_called = true;
+  });
+  return mgr;
+}
+
 using Axis = SkFontParameters::Variation::Axis;
 using Coordinate = SkFontArguments::VariationPosition::Coordinate;
 PYBIND11_MAKE_OPAQUE(std::vector<Coordinate>);
@@ -44,7 +88,7 @@ py::str SkFontMgr_getFamilyName(const SkFontMgr& fontmgr, int index) {
 sk_sp<SkTypeface> SkTypeface_MakeFromName(
     py::object familyName,
     const SkFontStyle* fontStyle) {
-    return SkTypeface::MakeFromName(
+    return SkFontMgr_RefDefault()->legacyMakeTypeface(
         (familyName.is_none()) ?
             nullptr : familyName.cast<std::string>().c_str(),
         (fontStyle) ? *fontStyle : SkFontStyle());
@@ -266,7 +310,7 @@ typeface
             warnings.attr("warn")(
                 "\"Default typeface\" is deprecated upstream. Please specify name/file/style choices.",
                 builtins.attr("DeprecationWarning"));
-            return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle());
+            return SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle());
         }),
         R"docstring(
         Returns the default normal typeface.
@@ -571,7 +615,7 @@ typeface
             warnings.attr("warn")(
                 "\"Default typeface\" is deprecated upstream. Please specify name/file/style choices.",
                 builtins.attr("DeprecationWarning"));
-            return SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle());
+            return SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle());
         },
         R"docstring(
         Returns the default normal typeface, which is never nullptr.
@@ -595,7 +639,7 @@ typeface
         py::arg("familyName"), py::arg("fontStyle") = nullptr)
     .def_static("MakeFromFile",
         [] (const std::string& path, int index) {
-            return SkTypeface::MakeFromFile(&path[0], index);
+            return SkFontMgr_RefDefault()->makeFromFile(&path[0], index);
         },
         R"docstring(
         Return a new typeface given a file.
@@ -606,7 +650,10 @@ typeface
         py::arg("path"), py::arg("index") = 0)
     // .def_static("MakeFromStream", &SkTypeface::MakeFromStream,
     //     "Return a new typeface given a stream.")
-    .def_static("MakeFromData", &SkTypeface::MakeFromData,
+    .def_static("MakeFromData",
+        [] (sk_sp<SkData> data, int index) {
+            return SkFontMgr_RefDefault()->makeFromData(data, index);
+        },
         R"docstring(
         Return a new typeface given a :py:class:`Data`.
 
@@ -618,9 +665,9 @@ typeface
     // .def_static("MakeFromFontData", &SkTypeface::MakeFromFontData,
     //     "Return a new typeface given font data and configuration.")
     .def_static("MakeDeserialize",
-        [] (const sk_sp<SkData>& data) {
+        [] (const sk_sp<SkData>& data, sk_sp<SkFontMgr> lastResortMgr) {
             SkMemoryStream stream(data);
-            return SkTypeface::MakeDeserialize(&stream);
+            return SkTypeface::MakeDeserialize(&stream, lastResortMgr);
         },
         R"docstring(
         Given the data previously written by :py:meth:`serialize`, return a new
@@ -628,7 +675,7 @@ typeface
 
         If that font is not available, return nullptr.
         )docstring",
-        py::arg("dats"))
+        py::arg("dats"), py::arg("lastResortMgr"))
     ;
 
 // FontMgr
@@ -660,7 +707,7 @@ py::class_<SkFontMgr, sk_sp<SkFontMgr>, SkRefCnt>(m, "FontMgr",
         assert typeface is not None
 
     )docstring")
-    .def(py::init([] () { return SkFontMgr::RefDefault(); }))
+    .def(py::init([] () { return SkFontMgr_RefDefault(); }))
     .def_static("New_Custom_Empty", &SkFontMgr_New_Custom_Empty)
     .def("__getitem__", &SkFontMgr_getFamilyName, py::arg("index"))
     .def("__len__", &SkFontMgr::countFamilies)
@@ -765,7 +812,7 @@ py::class_<SkFontMgr, sk_sp<SkFontMgr>, SkRefCnt>(m, "FontMgr",
             return fontmgr.legacyMakeTypeface(familyName.c_str(), style);
         },
         py::arg("familyName"), py::arg("style"))
-    .def_static("RefDefault", &SkFontMgr::RefDefault,
+    .def_static("RefDefault", &SkFontMgr_RefDefault,
         R"docstring(
         Return the default fontmgr.
         )docstring")
@@ -814,7 +861,7 @@ font
             warnings.attr("warn")(
                 "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
                 builtins.attr("DeprecationWarning"));
-            return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()));
+            return SkFont(SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle()));
         }),
         R"docstring(
         Constructs :py:class:`Font` with default values.
@@ -827,7 +874,7 @@ font
                 warnings.attr("warn")(
                     "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
                     builtins.attr("DeprecationWarning"));
-                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()), size);
+                return SkFont(SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle()), size);
             } else {
                 return SkFont(typeface.cast<sk_sp<SkTypeface>>(), size);
             }
@@ -849,7 +896,7 @@ font
                 warnings.attr("warn")(
                     "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
                     builtins.attr("DeprecationWarning"));
-                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()));
+                return SkFont(SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle()));
             } else {
                 return SkFont(typeface.cast<sk_sp<SkTypeface>>());
             }
@@ -870,7 +917,7 @@ font
                 warnings.attr("warn")(
                     "\"Default font\" is deprecated upstream. Please specify name/file/style choices.",
                     builtins.attr("DeprecationWarning"));
-                return SkFont(SkFontMgr::RefDefault()->legacyMakeTypeface("", SkFontStyle()),
+                return SkFont(SkFontMgr_RefDefault()->legacyMakeTypeface("", SkFontStyle()),
                                       size, scaleX, skewX);
             } else {
                 return SkFont(typeface.cast<sk_sp<SkTypeface>>(),

--- a/src/skia/Font.cpp
+++ b/src/skia/Font.cpp
@@ -10,7 +10,7 @@
 #include <src/ports/SkFontHost_FreeType_common.h>
 #endif
 
-#ifdef __apple__
+#ifdef __APPLE__
 #include "include/ports/SkFontMgr_mac_ct.h"
 #endif
 
@@ -31,7 +31,7 @@ bool g_factory_called = false;
 }  // namespace
 
 static sk_sp<SkFontMgr> fontmgr_factory() {
-#if defined(__apple__)
+#if defined(__APPLE__)
   return SkFontMgr_New_CoreText(nullptr);
 #elif defined(__linux__)
   return SkFontMgr_New_FontConfig(nullptr);

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -578,7 +578,8 @@ def test_Font_getPath(font, glyphs):
 def test_Font_getPaths(font, glyphs):
     paths = font.getPaths(glyphs)
     assert isinstance(paths, (list, type(None)))
-    assert paths[0] == font.getPath(glyphs[0])
+    if (not isinstance(paths, type(None))):
+        assert paths[0] == font.getPath(glyphs[0])
 
 
 def test_Font_getMetrics(font):

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -577,7 +577,7 @@ def test_Font_getPath(font, glyphs):
 
 def test_Font_getPaths(font, glyphs):
     paths = font.getPaths(glyphs)
-    assert isinstance(paths, (list, type(None))
+    assert isinstance(paths, (list, type(None)))
     assert paths[0] == font.getPath(glyphs[0])
 
 

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -572,14 +572,13 @@ def test_Font_getXPos(font, glyphs):
 
 
 def test_Font_getPath(font, glyphs):
-    assert isinstance(font.getPath(glyphs[0]), (skia.Path, type(None)))
+    assert isinstance(font.getPath(glyphs[0]), skia.Path)
 
 
 def test_Font_getPaths(font, glyphs):
     paths = font.getPaths(glyphs)
-    assert isinstance(paths, (list, type(None)))
-    if (not isinstance(paths, type(None))):
-        assert paths[0] == font.getPath(glyphs[0])
+    assert isinstance(paths, list)
+    assert paths[0] == font.getPath(glyphs[0])
 
 
 def test_Font_getMetrics(font):

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -219,9 +219,9 @@ def test_Typeface_MakeFromData(typeface, args):
         skia.Typeface.MakeFromData(*args), (skia.Typeface, type(None)))
 
 
-def test_Typeface_MakeDeserialize(typeface):
+def test_Typeface_MakeDeserialize(typeface, fontmgr):
     assert isinstance(
-        skia.Typeface.MakeDeserialize(typeface.serialize()), skia.Typeface)
+        skia.Typeface.MakeDeserialize(typeface.serialize(), fontmgr), skia.Typeface)
 
 
 @pytest.fixture

--- a/tests/test_font.py
+++ b/tests/test_font.py
@@ -572,12 +572,12 @@ def test_Font_getXPos(font, glyphs):
 
 
 def test_Font_getPath(font, glyphs):
-    assert isinstance(font.getPath(glyphs[0]), skia.Path)
+    assert isinstance(font.getPath(glyphs[0]), (skia.Path, type(None)))
 
 
 def test_Font_getPaths(font, glyphs):
     paths = font.getPaths(glyphs)
-    assert isinstance(paths, list)
+    assert isinstance(paths, (list, type(None))
     assert paths[0] == font.getPath(glyphs[0])
 
 


### PR DESCRIPTION
This should passed CI. But there is no reason of merging/upgrading at the moment, since all it differs is in default fontmgr being emulated.

@kyamagu I am not sure what is the problem, but the "FontConfigInterface" is the one being used up to 121 and being moved to chrome, but it segfaults , and somehow the "fontconfig" one, which was not and is not used anywhere, works. If you have time I'd appreciate your thought, but probably don't spend too much time on it, since we have something that "works", and this shouldn't be merged yet. 