### PR TITLE
M125 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,15 +74,12 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-12]
         arch: [auto64]
-        cp: ["cp3{7,8,9,10,11,12}"]
+        cp: ["cp3{8,9,10,11,12}"]
         include:
           - os: macos-12
             arch: arm64
-            cp: "cp3{7,8,9,10,11,12}"
+            cp: "cp3{8,9,10,11,12}"
           # aarch64 is emulated and takes longer, build one wheel per job
-          - os: ubuntu-22.04
-            arch: aarch64
-            cp: cp37
           - os: ubuntu-22.04
             arch: aarch64
             cp: cp38

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             skia
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m124-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m124-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m125-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m125-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build skia 3rd-Party

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Binary package is available on PyPI:
 pip install skia-python
 ```
 
-Supported platforms: Python 3.7-3.12 (CPython) on
+Supported platforms: Python 3.8-3.12 (CPython) on
 
 - Linux x86_64, aarch64
 - macOS x86_64, arm64

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -116,22 +116,20 @@ macOS
 
 Prerequisites:
 
-- Python 2.7 (build time only)
 - Xcode Command Line Tools
 
-Set up ``PATH`` to the ``depot_tools``, and build skia library. At this point,
-``python`` executable should be python 2.
+Set up ``PATH`` to the ``depot_tools``, and build skia library.
 
 .. code-block:: bash
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python2 tools/git-sync-deps
+    python tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
     ninja -C out/Release skia skia.h
     cd ..
 
-Then, build the skia python binding. At this point, ``python`` should be set to
+Then, build the skia-python binding. Here, ``python`` should be set to
 the desired version.
 
 .. code-block:: bash

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,7 @@ Linux
 
 Prerequisites:
 
-- Python 2.7 (build time only)
+- Python 3 (build time only)
 - GLIBC >= 2.17
 - fontconfig >= 2.10.93
 - OpenGL
@@ -89,14 +89,14 @@ or:
 
 
 Set up ``PATH`` to the ``depot_tools``. build skia library. At this point,
-``python`` executable should be python 2. Note the build tools require
-relatively new glibc and python 2.7.
+``python`` executable should be python 3. Note the build tools require
+relatively new glibc and python 3.
 
 .. code-block:: bash
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python2 tools/git-sync-deps
+    python tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
     ninja -C out/Release skia skia.h
     cd ..
@@ -124,7 +124,7 @@ Set up ``PATH`` to the ``depot_tools``, and build skia library.
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python tools/git-sync-deps
+    python3 tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
     ninja -C out/Release skia skia.h
     cd ..
@@ -144,8 +144,8 @@ Windows
 
 Prerequisites:
 
-- Python 2.7 (build time only)
-- Visual C++ version that supports C++14
+- Python 3 (build time only)
+- Visual C++ version that supports C++17
 
 Windows binary can be built using the generic steps above.
 
@@ -154,7 +154,7 @@ Windows binary can be built using the generic steps above.
     $env:Path += ";$pwd\depot_tools"
 
     cd skia
-    python2 tools\git-sync-deps
+    python tools\git-sync-deps
     bin\gn gen out\Release --args="is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/GR\", \"/EHsc\", \"/MD\"] target_cpu=\"x86_64\""
     ninja -C out\Release skia skia.h
     cd ..

--- a/patch/skia-m125-minimize-download.patch
+++ b/patch/skia-m125-minimize-download.patch
@@ -1,0 +1,69 @@
+diff --git a/DEPS b/DEPS
+index 34462a7..0664739 100644
+--- a/DEPS
++++ b/DEPS
+@@ -23,52 +23,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@66bc9cfa00143312cc7545556041622a92745a91",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@f20a53466bc2cd5c86f0f903a9eea322cadf8b77",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@e2d024354e11cc6b041b0cff032d73f0c7e43a07",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@334aca32051ef6ede2711487acf45d959e9bdffc",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@f42ce25563b73fed0123d18a2556b9ba01d2c76b",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@c053e8f29257814e11ad61493dbbe29f27656de4",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@a0718d4f121727e30b8d52c7a189ebf5ab52421f",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@bcf4f7198d4dc5f3127e84a6ca657c88e7d07a13",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@ed683925e4897a84b3bffc5c1414c85b97a129a3",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@144b348e072a78e8130ed0acc452c9f039a67bf2",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@ca332209cb5567c9b249c86788cb2dbf8847e760",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@62c59c41e194c288c06739788bb0aad3c86b19bf",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@ec0c320a8ca186363f609b697c037597398a43e6",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+   "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@4f7b471f1a66b6d06462cd4ba57628cc0cd087d7",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@2904985aee4de2fd67d697242a267f5ec31814ce",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@74715ee4650ec3f4483ccc86540b32d15d5bfaa3",
+-  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@1e7b8a6d03d30c9254b5f533b561d62bba8c3199",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@d14404b26e17086a707ea6ff5f7342ed5b9938ca",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@72696f278218d39171678e41d8f43cff9905c513",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@646b7f569718921d7d4b5b8e22572ff6c76f2596",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/relnotes/README.m124.md
+++ b/relnotes/README.m124.md
@@ -2,7 +2,7 @@ New to m124:
 
 * The skia.SamplingOptions class has been fleshed out.
 
-  To migrate from m87 SkFilterQuality-based code:
+  To migrate from m87 FilterQuality-based code:
 
   FilterQuality.kHigh_FilterQuality   -> SamplingOptions(CubicResampler.Mitchell())
   FilterQuality.kMedium_FilterQuality -> SamplingOptions(FilterMode.kLinear, MipmapMode.kNearest)    // cpu

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -60,7 +60,7 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m124-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m125-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,7 +4,7 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m124-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m125-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,7 +22,7 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m124-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m125-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -35,6 +35,7 @@ skia_use_system_libjpeg_turbo=false
 skia_use_system_libwebp=false
 skia_use_system_libpng=false
 skia_use_system_icu=false
+skia_use_metal=true
 skia_use_system_harfbuzz=false
 skia_use_system_expat=false
 extra_cflags_cc=[\"-frtti\"]

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ elif sys.platform == 'darwin':
         ('VERSION_INFO', __version__),
         ('SK_GL', ''),
         ('SK_GANESH', '1'),
+        ('SK_METAL', ''),
     ]
     LIBRARIES = [
         'dl',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '124.0b7'
+__version__ = '125.0b7'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.platform == 'win32':
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'svg.lib'), os.path.join(SKIA_OUT_PATH, 'skresources.lib'), os.path.join(SKIA_OUT_PATH, 'skia.lib'),
          os.path.join(SKIA_OUT_PATH, 'skshaper.lib'),
-         os.path.join(SKIA_OUT_PATH, 'unicode_core.lib'), os.path.join(SKIA_OUT_PATH, 'unicode_icu.lib')]
+         os.path.join(SKIA_OUT_PATH, 'skunicode_icu.lib'), os.path.join(SKIA_OUT_PATH, 'skunicode_core.lib')]
     EXTRA_COMPILE_ARGS = [
         '/std:c++17',  # c++20 fails.
         '/DVERSION_INFO=%s' % __version__,
@@ -66,7 +66,7 @@ elif sys.platform == 'darwin':
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'libsvg.a'), os.path.join(SKIA_OUT_PATH, 'libskia.a'),
          os.path.join(SKIA_OUT_PATH, 'libskshaper.a'),
-         os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a')]
+         os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a')]
     EXTRA_COMPILE_ARGS = [
         '-std=c++17',
         '-stdlib=libc++',
@@ -100,7 +100,7 @@ else:
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'libsvg.a'), os.path.join(SKIA_OUT_PATH, 'libskresources.a'), os.path.join(SKIA_OUT_PATH, 'libskia.a'),
          os.path.join(SKIA_OUT_PATH, 'libskshaper.a'),
-         os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a')]
+         os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a')]
     EXTRA_COMPILE_ARGS = [
         '-std=c++17',
         '-fvisibility=hidden',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ if sys.platform == 'win32':
     ]
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'svg.lib'), os.path.join(SKIA_OUT_PATH, 'skresources.lib'), os.path.join(SKIA_OUT_PATH, 'skia.lib'),
-         os.path.join(SKIA_OUT_PATH, 'skshaper.lib'), os.path.join(SKIA_OUT_PATH, 'skunicode.lib')]
+         os.path.join(SKIA_OUT_PATH, 'skshaper.lib'),
+         os.path.join(SKIA_OUT_PATH, 'unicode_core.lib'), os.path.join(SKIA_OUT_PATH, 'unicode_icu.lib')]
     EXTRA_COMPILE_ARGS = [
         '/std:c++17',  # c++20 fails.
         '/DVERSION_INFO=%s' % __version__,
@@ -64,7 +65,8 @@ elif sys.platform == 'darwin':
     ]
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'libsvg.a'), os.path.join(SKIA_OUT_PATH, 'libskia.a'),
-         os.path.join(SKIA_OUT_PATH, 'libskshaper.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode.a')]
+         os.path.join(SKIA_OUT_PATH, 'libskshaper.a'),
+         os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a')]
     EXTRA_COMPILE_ARGS = [
         '-std=c++17',
         '-stdlib=libc++',
@@ -97,7 +99,8 @@ else:
     ]
     EXTRA_OBJECTS = list(
     ) + [os.path.join(SKIA_OUT_PATH, 'libsvg.a'), os.path.join(SKIA_OUT_PATH, 'libskresources.a'), os.path.join(SKIA_OUT_PATH, 'libskia.a'),
-         os.path.join(SKIA_OUT_PATH, 'libskshaper.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode.a')]
+         os.path.join(SKIA_OUT_PATH, 'libskshaper.a'),
+         os.path.join(SKIA_OUT_PATH, 'libskunicode_core.a'), os.path.join(SKIA_OUT_PATH, 'libskunicode_icu.a')]
     EXTRA_COMPILE_ARGS = [
         '-std=c++17',
         '-fvisibility=hidden',

--- a/src/skia/Canvas.cpp
+++ b/src/skia/Canvas.cpp
@@ -1586,7 +1586,7 @@ canvas
             to draw
         )docstring",
         py::arg("center"), py::arg("radius"), py::arg("paint"))
-    .def("drawArc", &SkCanvas::drawArc,
+    .def("drawArc", py::overload_cast<const SkRect&, SkScalar, SkScalar, bool, const SkPaint&>(&SkCanvas::drawArc),
         R"docstring(
         Draws arc using clip, :py:class:`Matrix`, and :py:class:`Paint` paint.
 

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -540,7 +540,6 @@ py::class_<GrContext_Base, sk_sp<GrContext_Base>, SkRefCnt>(m, "GrContext_Base")
         R"docstring(
         The 3D API backing this context.
         )docstring")
-/*
     .def("defaultBackendFormat", &GrContext_Base::defaultBackendFormat,
         R"docstring(
         Retrieve the default :py:class:`GrBackendFormat` for a given
@@ -552,7 +551,6 @@ py::class_<GrContext_Base, sk_sp<GrContext_Base>, SkRefCnt>(m, "GrContext_Base")
         The caller should check that the returned format is valid.
         )docstring")
     .def("compressedBackendFormat", &GrContext_Base::compressedBackendFormat)
-*/
     .def("threadSafeProxy", &GrContext_Base::threadSafeProxy)
     // .def("priv", py::overload_cast<>(&GrContext_Base::priv))
     // .def("priv", py::overload_cast<>(&GrContext_Base::priv, py::const_))

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -17,7 +17,6 @@
 #include <include/gpu/ganesh/mtl/GrMtlBackendSurface.h>
 #include <include/gpu/ganesh/mtl/GrMtlDirectContext.h>
 #endif
-#include <include/gpu/vk/VulkanTypes.h>
 #include <include/gpu/vk/GrVkBackendContext.h>
 #include <include/gpu/MutableTextureState.h>
 #include <pybind11/chrono.h>

--- a/src/skia/Path.cpp
+++ b/src/skia/Path.cpp
@@ -841,7 +841,7 @@ path
         py::arg("rect"))
     .def("incReserve", &SkPath::incReserve,
         R"docstring(
-        Grows :py:class:`Path` verb array and :py:class:`Point` array to contain
+        Grows :py:class:`Path` verb array, :py:class:`Point` array and comics to contain
         extraPtCount additional :py:class:`Point`.
 
         May improve performance and use less memory by reducing the number and
@@ -849,8 +849,10 @@ path
 
         :param int extraPtCount: number of additional :py:class:`Point` to
             allocate
+        :param int extraVerbCount: number of additional verbs
+        :param int extraConicCount: number of additional conics
         )docstring",
-        py::arg("extraPtCount"))
+        py::arg("extraPtCount"), py::arg("extraVerbCount") = 0, py::arg("extraConicCount") = 0)
 /* TODO: This was removed in m88
     .def("shrinkToFit", &SkPath::shrinkToFit,
         R"docstring(

--- a/src/skia/Stream.cpp
+++ b/src/skia/Stream.cpp
@@ -678,9 +678,12 @@ py::class_<SkMemoryStream, PyMemoryStream<>, SkStreamMemory>(m, "MemoryStream")
         py::arg("data"), py::arg("copyData") = false)
     .def("asData", &SkMemoryStream::getData)
     .def("setData", &SkMemoryStream::setData, py::arg("data"))
-/*
-    .def("skipToAlign4", &SkMemoryStream::skipToAlign4)
-*/
+    .def("skipToAlign4",
+        [] (SkMemoryStream& stream) {
+            // cast to remove unary-minus warning
+            stream.fOffset += -(int)stream.fOffset & 0x03;
+        }
+        )
     .def("getAtPos", &SkMemoryStream::getAtPos)
     ;
 

--- a/src/skia/Stream.cpp
+++ b/src/skia/Stream.cpp
@@ -676,9 +676,7 @@ py::class_<SkMemoryStream, PyMemoryStream<>, SkStreamMemory>(m, "MemoryStream")
             stream.setMemory(info.ptr, size, copyData);
         },
         py::arg("data"), py::arg("copyData") = false)
-/*
-    .def("asData", &SkMemoryStream::asData)
-*/
+    .def("asData", &SkMemoryStream::getData)
     .def("setData", &SkMemoryStream::setData, py::arg("data"))
 /*
     .def("skipToAlign4", &SkMemoryStream::skipToAlign4)

--- a/src/skia/Stream.cpp
+++ b/src/skia/Stream.cpp
@@ -676,9 +676,13 @@ py::class_<SkMemoryStream, PyMemoryStream<>, SkStreamMemory>(m, "MemoryStream")
             stream.setMemory(info.ptr, size, copyData);
         },
         py::arg("data"), py::arg("copyData") = false)
+/*
     .def("asData", &SkMemoryStream::asData)
+*/
     .def("setData", &SkMemoryStream::setData, py::arg("data"))
+/*
     .def("skipToAlign4", &SkMemoryStream::skipToAlign4)
+*/
     .def("getAtPos", &SkMemoryStream::getAtPos)
     ;
 

--- a/src/skia/Stream.cpp
+++ b/src/skia/Stream.cpp
@@ -680,8 +680,10 @@ py::class_<SkMemoryStream, PyMemoryStream<>, SkStreamMemory>(m, "MemoryStream")
     .def("setData", &SkMemoryStream::setData, py::arg("data"))
     .def("skipToAlign4",
         [] (SkMemoryStream& stream) {
+            size_t fOffset = stream.getPosition();
             // cast to remove unary-minus warning
-            stream.fOffset += -(int)stream.fOffset & 0x03;
+            fOffset += -(int)fOffset & 0x03;
+            stream.seek(fOffset);
         }
         )
     .def("getAtPos", &SkMemoryStream::getAtPos)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -273,7 +273,6 @@ def test_MemoryStream_setData(memory_stream):
     memory_stream.setData(data)
 
 
-@pytest.mark.skip(reason='m125:REVISIT; Apparently replaced by SkRBuffer::skipToAlign4')
 def test_MemoryStream_skipToAlign4(memory_stream):
     memory_stream.skipToAlign4()
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -273,6 +273,7 @@ def test_MemoryStream_setData(memory_stream):
     memory_stream.setData(data)
 
 
+@pytest.mark.skip(reason='m125:REVISIT; Apparently replaced by SkRBuffer::skipToAlign4')
 def test_MemoryStream_skipToAlign4(memory_stream):
     memory_stream.skipToAlign4()
 


### PR DESCRIPTION
M125 is out, small adjustments in skpath, changes in MemoryStream looks slightly complicated, and libunicode has split into _core and _icu and it seems we needs both; and it seems to require the internal copy of libicu (and doesn't work with my system-wide one).

The icu part looks to be a bit inconvenient (for my personal build, which uses a lot of more system libraries than the wheels). The tests don't run on my system for that reason (having problem loading the system libicu) but should work on CI.