### PR TITLE
`git-sync-deps` seems to no longer require or support Python 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -116,22 +116,20 @@ macOS
 
 Prerequisites:
 
-- Python 2.7 (build time only)
 - Xcode Command Line Tools
 
-Set up ``PATH`` to the ``depot_tools``, and build skia library. At this point,
-``python`` executable should be python 2.
+Set up ``PATH`` to the ``depot_tools``, and build skia library.
 
 .. code-block:: bash
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python2 tools/git-sync-deps
+    python tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
     ninja -C out/Release skia skia.h
     cd ..
 
-Then, build the skia python binding. At this point, ``python`` should be set to
+Then, build the skia-python binding. Here, ``python`` should be set to
 the desired version.
 
 .. code-block:: bash

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,7 @@ Linux
 
 Prerequisites:
 
-- Python 2.7 (build time only)
+- Python 3 (build time only)
 - GLIBC >= 2.17
 - fontconfig >= 2.10.93
 - OpenGL
@@ -89,14 +89,14 @@ or:
 
 
 Set up ``PATH`` to the ``depot_tools``. build skia library. At this point,
-``python`` executable should be python 2. Note the build tools require
-relatively new glibc and python 2.7.
+``python`` executable should be python 3. Note the build tools require
+relatively new glibc and python 3.
 
 .. code-block:: bash
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python2 tools/git-sync-deps
+    python tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"] extra_ldflags=["-lrt"]'
     ninja -C out/Release skia skia.h
     cd ..
@@ -124,7 +124,7 @@ Set up ``PATH`` to the ``depot_tools``, and build skia library.
 
     export PATH="$PWD/depot_tools:$PATH"
     cd skia
-    python tools/git-sync-deps
+    python3 tools/git-sync-deps
     bin/gn gen out/Release --args='is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false extra_cflags_cc=["-frtti"]'
     ninja -C out/Release skia skia.h
     cd ..
@@ -144,8 +144,8 @@ Windows
 
 Prerequisites:
 
-- Python 2.7 (build time only)
-- Visual C++ version that supports C++14
+- Python 3 (build time only)
+- Visual C++ version that supports C++17
 
 Windows binary can be built using the generic steps above.
 
@@ -154,7 +154,7 @@ Windows binary can be built using the generic steps above.
     $env:Path += ";$pwd\depot_tools"
 
     cd skia
-    python2 tools\git-sync-deps
+    python tools\git-sync-deps
     bin\gn gen out\Release --args="is_official_build=true skia_enable_tools=true skia_use_system_libjpeg_turbo=false skia_use_system_libwebp=false skia_use_system_libpng=false skia_use_system_icu=false skia_use_system_harfbuzz=false skia_use_system_expat=false skia_use_system_zlib=false extra_cflags_cc=[\"/GR\", \"/EHsc\", \"/MD\"] target_cpu=\"x86_64\""
     ninja -C out\Release skia skia.h
     cd ..


### PR DESCRIPTION
This PR removes the mention of Python 2 from the macOS build instructions.

I just ran through the installation instructions on macOS and `tools/git-sync-deps` in the Skia build instructions no longer need or allow Python 2. I am guessing the Windows and Linux build instructions also need to be updated; that said, I'm a bit worried to propose those because I haven't tested on those operating systems.