### PR TITLE
Improve "convert to PIL" example

### DIFF
--- a/notebooks/Python-Image-IO.ipynb
+++ b/notebooks/Python-Image-IO.ipynb
@@ -309,7 +309,8 @@
     "\n",
     "Note that `PIL.Image` supports limited image modes. Apart from `skia.kRGBA_8888_ColorType` format, many pixel formats in skia are not compatible.\n",
     "\n",
-    "Default alpha type of `skia.Image` is `skia.kPremul_AlphaType`. To convert `skia.Image` to `PIL.Image`, make sure to first convert the alpha type before calling `fromarray`:"
+    "The default alpha type of `skia.Image` is `skia.kPremul_AlphaType`, whereas the default color type is platform dependent.\n",
+    "To convert `skia.Image` to `PIL.Image`, make sure to first convert the alpha type and the color type before calling `fromarray`:"
    ]
   },
   {
@@ -322,7 +323,7 @@
    "source": [
     "skia_image = skia.Image.open('../skia/resources/images/rainbow-gradient.png')\n",
     "\n",
-    "pil_image = PIL.Image.fromarray(skia_image.convert(alphaType=skia.kUnpremul_AlphaType))"
+    "pil_image = PIL.Image.fromarray(skia_image.convert(alphaType=skia.kUnpremul_AlphaType, colorType=skia.kRGBA_8888_ColorType))"
    ]
   },
   {


### PR DESCRIPTION
The default color type of a `skia.Image` is platform dependent. On some systems (e.g., GitHub CI, and most Linux systems) the default color type is BGR (for endianness purposes).

See https://github.com/google/skia/blob/6ffe89f9b4cc8c1dae9c4a916f16f9c463e3fa6d/include/core/SkColorType.h#L58-L62

Thus, in general, not only one has to convert the `alphaType` to create a PIL image, but also the `colorType`.