### PR TITLE
M127 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }}
+          CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }} MACOSX_DEPLOYMENT_TARGET=10.13
           CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
           CIBW_BEFORE_BUILD: pip install pybind11 numpy
           CIBW_TEST_REQUIRES: pytest pillow glfw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build skia 3rd-Party
-        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.16.2/cibuildwheel/resources/pinned_docker_images.cfg
-        uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-10-03-72cdc42
+        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.19.2/cibuildwheel/resources/pinned_docker_images.cfg
+        uses: docker://quay.io/pypa/manylinux2014_aarch64:2024.07.02-0
         if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
         with:
           args: bash -c "git config --global --add safe.directory '*' &&
@@ -60,7 +60,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build Skia Proper
-        uses: docker://quay.io/pypa/manylinux2014_aarch64:2023-10-03-72cdc42
+        uses: docker://quay.io/pypa/manylinux2014_aarch64:2024.07.02-0
         with:
           args: bash -c "git config --global --add safe.directory '*' &&
                          bash scripts/build_Linux.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             skia
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Pre-fetch skia deps
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m126-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m126-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m127-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m127-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build skia 3rd-Party

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           platforms: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.19.2
         env:
           CIBW_BUILD: "${{ matrix.cp }}-*"
           CIBW_SKIP: "*musllinux*"

--- a/docs/tutorial/canvas.rst
+++ b/docs/tutorial/canvas.rst
@@ -90,6 +90,11 @@ The following example uses glfw package to create an OpenGL context. Install
             raise RuntimeError('glfw.init() failed')
         glfw.window_hint(glfw.VISIBLE, glfw.FALSE)
         glfw.window_hint(glfw.STENCIL_BITS, 8)
+        # see https://www.glfw.org/faq#macos
+        glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+        glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 2)
+        glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+        glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         window = glfw.create_window(640, 480, '', None, None)
         glfw.make_context_current(window)
         yield window
@@ -138,6 +143,11 @@ Here's a complete example:
         if not glfw.init():
             raise RuntimeError('glfw.init() failed')
         glfw.window_hint(glfw.STENCIL_BITS, 8)
+        # see https://www.glfw.org/faq#macos
+        glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+        glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 2)
+        glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+        glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
         window = glfw.create_window(WIDTH, HEIGHT, '', None, None)
         glfw.make_context_current(window)
         yield window

--- a/patch/skia-m127-minimize-download.patch
+++ b/patch/skia-m127-minimize-download.patch
@@ -1,0 +1,69 @@
+diff --git a/DEPS b/DEPS
+index 007d053..17e50d8 100644
+--- a/DEPS
++++ b/DEPS
+@@ -23,52 +23,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@b138e6ce86ae843c42a1a08f37903207bebcca75",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@3a3b55f7ac9bee70e875e7cfb9b0c05b2ed9b7cf",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@51d873f3e0d0e0dcc5c3a6b56019983a5a4cd155",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@e2d024354e11cc6b041b0cff032d73f0c7e43a07",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@65a55c2ba891f6d2492477707f4a2e327a0b40dc",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@c8d0c9b1d16bfda56f15165d39e0ffa360a11123",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@441f98d02deafd9b090aea568282b28f66a50e36",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@a46424228f0998a72c715f32e18dca8a7a764c1f",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@b74a7ecc93e283d059df51ee4f46961a782bcdb8",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@364118a1d9da24bb5b770ac3d762ac144d6da5a4",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@bcf4f7198d4dc5f3127e84a6ca657c88e7d07a13",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@ccfbe1c82a3b6dbe8647ceb36a3f9ee711fba3cf",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@ed217e3e601d8e462f7fd1e04bed43ac42212429",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@845d5476a866141ba35ac133f856fa62f0b7445f",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/microhttpd"             : "https://android.googlesource.com/platform/external/libmicrohttpd@748945ec6f1c67b7efc934ab0808e1d32f2fb98d",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@2ff3212615da62f591be15eef78721c29c5c0b31",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@62eb765e42dd2ab2ca58f6c95fac89de123978e7",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+   "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@eb49bb7b1136298b77945c52b4bbbc433f7885de",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@ce46482db7ab3ea9c52fce832d27ca40b14f8e87",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@6938a2893d6a2ba658709d1d04720f6c6033700f",
+-  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@d192041a2fc9c9fd8ae67d8ae3f32c5511541f04",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@a9a1bcd709e185700847268eb4310f6484b027bc",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@741921e408442b0370047b5eaf16cbc2b5d381e5",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@646b7f569718921d7d4b5b8e22572ff6c76f2596",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/relnotes/README.m116.md
+++ b/relnotes/README.m116.md
@@ -21,6 +21,9 @@ of this update had taken from.
 * TL;DR - `m87` users would likely find most existing python scripts work. Some
   routines need a new `skia.SamplingOptions()` argument, or
   switch from `skia.FilterQuality` to `skia.SamplingOptions()`.
+  OpenGL users, especially on Apple Mac OS, may now need to specify
+  a compatible OpenGL profile for their GPU hardware/software combination
+  to avoid shader-compilation related errors (See more about this below).
   Please report `AttributeError: 'skia.AAA' object has no attribute 'BBB'` errors,
   to prioritize fixing remaining differences between `m87` and `m116`.
 
@@ -37,6 +40,33 @@ of this update had taken from.
 * Be **WARN**'ed: some `m87` APIs (about 5% in total, many in the `ImageFilter` namespace)
   are removed/disabled when there are no obvious new-equivalents, or not-too-troblesome
   emulations with `m116`. The "AttributeError" error mentioned above.
+
+* Be **WARN**'ed on OpenGL usage: Google folks added subtantial GPU/driver
+  detection code in upsteam Skia between m87 and m116, to optimize for speed and
+  work-around driver bugs. If you use a non-open-source GPU driver, i.e.
+  everybody except Mesa on Linux, and especially Apple Mac users,
+  you may need to request compatible OpenGL profile to match the your
+  GPU/driver's capability. For Apple Mac users, with `glfw`, adds the following:
+
+```
+# see https://www.glfw.org/faq#macos
+glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 2)
+glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+```
+
+  OSX OpenGL users may need to add `GLUT_3_2_CORE_PROFILE` to their `glutInitDisplayMode()`
+  invocation e.g. `glutInitDisplayMode(... | GLUT_3_2_CORE_PROFILE)`. `pysdl2` users
+  need:
+
+```
+sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, 3)
+sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MINOR_VERSION, 2)
+sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG, True)
+sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_PROFILE_MASK,
+                         sdl2.SDL_GL_CONTEXT_PROFILE_CORE)
+```
 
 * Where it is possible, when `m87` APIs disappear, emulations with `m116`
   is done. So these are "new emulations of old APIs". While they work,

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -60,7 +60,7 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m126-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m127-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,7 +4,7 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m126-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m127-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,7 +22,7 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m126-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m127-minimize-download.patch && \
     patch -p1 < ../patch/skia-m123-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '126.0b8'
+__version__ = '127.0b8'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -447,6 +447,9 @@ py::class_<GrBackendRenderTarget>(m, "GrBackendRenderTarget")
         }),
         py::arg("width"), py::arg("height"), py::arg("sampleCnt"),
         py::arg("stencilBits"), py::arg("glInfo"))
+    .def_static("MakeGL", &GrBackendRenderTargets::MakeGL,
+        py::arg("width"), py::arg("height"), py::arg("sampleCnt"),
+        py::arg("stencilBits"), py::arg("glInfo"))
 #ifdef SK_VULKAN
     .def(py::init(
         [] (int width, int height, const GrVkImageInfo& vkInfo) {
@@ -1320,6 +1323,10 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     ;
 
 m.attr("GrContext") = m.attr("GrDirectContext");
+
+// GrDirectContexts and GrBackendRenderTargets are namespaces
+m.attr("GrDirectContexts")       = m.attr("GrDirectContext");
+m.attr("GrBackendRenderTargets") = m.attr("GrBackendRenderTarget");
 
 initGrContext_gl(m);
 initGrContext_vk(m);

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -1231,7 +1231,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
 
 #ifdef SK_VULKAN
     .def_static("MakeVulkan",
-        py::overload_cast<const GrVkBackendContext&, const GrContextOptions&>(
+        py::overload_cast<const skgpu::VulkanBackendContext&, const GrContextOptions&>(
             &GrDirectContexts::MakeVulkan),
         R"docstring(
         The Vulkan context (VkQueue, VkDevice, VkInstance) must be kept alive
@@ -1243,7 +1243,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
         )docstring",
         py::arg("backendContext"), py::arg("options"))
     .def_static("MakeVulkan",
-        py::overload_cast<const GrVkBackendContext&>(
+        py::overload_cast<const skgpu::VulkanBackendContext&>(
             &GrDirectContexts::MakeVulkan),
         py::arg("backendContext"))
 #endif

--- a/src/skia/GrContext_vk.cpp
+++ b/src/skia/GrContext_vk.cpp
@@ -96,7 +96,7 @@ py::enum_<GrVkFeatureFlags>(m, "GrVkFeatureFlags", py::arithmetic())
         GrVkFeatureFlags::kSampleRateShading_GrVkFeatureFlag)
     .export_values();
 
-py::class_<GrVkBackendContext>(m, "GrVkBackendContext",
+py::class_<skgpu::VulkanBackendContext>(m, "GrVkBackendContext",
     R"docstring(
     The BackendContext contains all of the base Vulkan objects needed by the
     GrVkGpu. The assumption is that the client will set these up and pass them

--- a/src/skia/GrContext_vk.cpp
+++ b/src/skia/GrContext_vk.cpp
@@ -70,6 +70,8 @@ py::class_<GrVkDrawableInfo>(m, "GrVkDrawableInfo")
     ;
 
 // GrVkBackendContext.h
+/* GrVkExtensionFlags & GrVkFeatureFlags removed in m127 */
+/*
 py::enum_<GrVkExtensionFlags>(m, "GrVkExtensionFlags", py::arithmetic())
     .value("kEXT_debug_report_GrVkExtensionFlag",
         GrVkExtensionFlags::kEXT_debug_report_GrVkExtensionFlag)
@@ -95,6 +97,7 @@ py::enum_<GrVkFeatureFlags>(m, "GrVkFeatureFlags", py::arithmetic())
     .value("kSampleRateShading_GrVkFeatureFlag",
         GrVkFeatureFlags::kSampleRateShading_GrVkFeatureFlag)
     .export_values();
+*/
 
 py::class_<skgpu::VulkanBackendContext>(m, "GrVkBackendContext",
     R"docstring(

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -71,7 +71,15 @@ py::enum_<SkSurfaceProps::Flags>(surfaceprops, "Flags", py::arithmetic())
         SkSurfaceProps::Flags::kAlwaysDither_Flag)
     .export_values();
 
-/* SkSurfaceProps::kLegacyFontHost_InitType was removed in m88 */
+/* SkSurfaceProps::kLegacyFontHost_InitType was removed in m88.
+   Its usage was replaced by:
+       SkSurfaceProps(SkSurfaceProps::kLegacyFontHost_InitType)
+           -> SkSurfaceProps() - private in m87 to public in m88
+       SkSurfaceProps(SkSurfaceProps::kUseDeviceIndependentFonts_Flag,
+                      SkSurfaceProps::kLegacyFontHost_InitType)
+           -> SkSurfaceProps(SkSurfaceProps::kUseDeviceIndependentFonts_Flag,
+                             SkSurfaceProps::kUnknown_SkPixelGeometry) - different constructor
+ */
 
 surfaceprops
     .def(py::init<>())

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -70,6 +70,7 @@ py::enum_<SkSurfaceProps::Flags>(surfaceprops, "Flags", py::arithmetic())
 /* SkSurfaceProps::kLegacyFontHost_InitType was removed in m88 */
 
 surfaceprops
+    .def(py::init<>())
     .def(py::init<uint32_t, SkPixelGeometry>(),
         py::arg("flags"), py::arg("geometry"))
 /*

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -1106,6 +1106,39 @@ surface
         py::arg("context"), py::arg("backendRenderTarget"), py::arg("origin"),
         py::arg("colorType"), py::arg("colorSpace"),
         py::arg("surfaceProps") = nullptr)
+    .def_static("WrapBackendRenderTarget", &SkSurfaces::WrapBackendRenderTarget,
+        R"docstring(
+        Wraps a GPU-backed buffer into :py:class:`Surface`.
+
+        Caller must ensure backendRenderTarget is valid for the lifetime of
+        returned :py:class:`Surface`.
+
+        :py:class:`Surface` is returned if all parameters are valid.
+        backendRenderTarget is valid if its pixel configuration agrees with
+        colorSpace and context; for instance, if backendRenderTarget has an sRGB
+        configuration, then context must support sRGB, and colorSpace must be
+        present. Further, backendRenderTarget width and height must not exceed
+        context capabilities, and the context must be able to support back-end
+        render targets.
+
+        Upon success releaseProc is called when it is safe to delete the render
+        target in the backend API (accounting only for use of the render target
+        by this surface). If :py:class:`Surface` creation fails releaseProc is
+        called before this function returns.
+
+        If SK_SUPPORT_GPU is defined as zero, has no effect and returns nullptr.
+
+        :param context: GPU context
+        :param backendRenderTarget: GPU intermediate memory buffer
+        :param colorSpace:  range of colors
+        :param surfaceProps:    LCD striping orientation and setting for device
+            independent fonts; may be nullptr
+        :return: :py:class:`Surface` if all parameters are valid; otherwise,
+            nullptr
+        )docstring",
+        py::arg("context"), py::arg("backendRenderTarget"), py::arg("origin"),
+        py::arg("colorType"), py::arg("colorSpace"),
+        py::arg("surfaceProps") = nullptr, py::arg("releaseProc") = nullptr, py::arg("releaseContext") = nullptr)
     .def_static("MakeRenderTarget",
         py::overload_cast<GrRecordingContext*, skgpu::Budgeted, const SkImageInfo&, int,
         GrSurfaceOrigin, const SkSurfaceProps*, bool, bool>(
@@ -1237,4 +1270,8 @@ surface
         )docstring",
         py::arg("width"), py::arg("height"))
     ;
+
+// Surfaces is a namespace
+m.attr("Surfaces") = m.attr("Surface");
+m.attr("Surface").attr("Raster") = m.attr("Surface").attr("MakeRaster");
 }

--- a/src/skia/Surface.cpp
+++ b/src/skia/Surface.cpp
@@ -65,6 +65,10 @@ py::class_<SkSurfaceProps> surfaceprops(m, "SurfaceProps", R"docstring(
 py::enum_<SkSurfaceProps::Flags>(surfaceprops, "Flags", py::arithmetic())
     .value("kUseDeviceIndependentFonts_Flag",
         SkSurfaceProps::Flags::kUseDeviceIndependentFonts_Flag)
+    .value("kDynamicMSAA_Flag",
+        SkSurfaceProps::Flags::kDynamicMSAA_Flag)
+    .value("kAlwaysDither_Flag",
+        SkSurfaceProps::Flags::kAlwaysDither_Flag)
     .export_values();
 
 /* SkSurfaceProps::kLegacyFontHost_InitType was removed in m88 */

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,11 @@ def glfw_context():
         raise RuntimeError('glfw.init() failed')
     glfw.window_hint(glfw.VISIBLE, glfw.FALSE)
     glfw.window_hint(glfw.STENCIL_BITS, 8)
+    # see https://www.glfw.org/faq#macos
+    glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+    glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 2)
+    glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+    glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
     context = glfw.create_window(640, 480, '', None, None)
     glfw.make_context_current(context)
     logger.debug('glfw context created')

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -179,7 +179,7 @@ def test_Surface_ref_unref(surface):
     (
         skia.ImageInfo.MakeN32Premul(16, 16), bytearray(16 * 16 * 4),
         16 * 4,
-        skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType),),
+        skia.SurfaceProps(),),
 ])
 def test_Surface_MakeRasterDirect(args):
     check_surface(skia.Surface.MakeRasterDirect(*args))
@@ -191,7 +191,7 @@ def test_Surface_MakeRasterDirect(args):
     (
         skia.ImageInfo.MakeN32Premul(16, 16),
         16 * 4,
-        skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType),),
+        skia.SurfaceProps(),),
 ])
 def test_Surface_MakeRaster(args):
     check_surface(skia.Surface.MakeRaster(*args))
@@ -199,7 +199,7 @@ def test_Surface_MakeRaster(args):
 
 @pytest.mark.parametrize('args', [
     (320, 240),
-    (320, 240, skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType)),
+    (320, 240, skia.SurfaceProps()),
 ])
 def test_Surface_MakeRasterN32Premul(args):
     check_surface(skia.Surface.MakeRasterN32Premul(*args))

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -176,6 +176,10 @@ def test_Surface_ref_unref(surface):
 @pytest.mark.parametrize('args', [
     (skia.ImageInfo.MakeN32Premul(16, 16), bytearray(16 * 16 * 4)),
     (skia.ImageInfo.MakeN32Premul(16, 16), bytearray(16 * 16 * 4), 16 * 4),
+    (
+        skia.ImageInfo.MakeN32Premul(16, 16), bytearray(16 * 16 * 4),
+        16 * 4,
+        skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType),),
 ])
 def test_Surface_MakeRasterDirect(args):
     check_surface(skia.Surface.MakeRasterDirect(*args))
@@ -184,6 +188,10 @@ def test_Surface_MakeRasterDirect(args):
 @pytest.mark.parametrize('args', [
     (skia.ImageInfo.MakeN32Premul(16, 16),),
     (skia.ImageInfo.MakeN32Premul(16, 16), 16 * 4),
+    (
+        skia.ImageInfo.MakeN32Premul(16, 16),
+        16 * 4,
+        skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType),),
 ])
 def test_Surface_MakeRaster(args):
     check_surface(skia.Surface.MakeRaster(*args))
@@ -191,6 +199,7 @@ def test_Surface_MakeRaster(args):
 
 @pytest.mark.parametrize('args', [
     (320, 240),
+    (320, 240, skia.SurfaceProps(skia.SurfaceProps.kLegacyFontHost_InitType)),
 ])
 def test_Surface_MakeRasterN32Premul(args):
     check_surface(skia.Surface.MakeRasterN32Premul(*args))


### PR DESCRIPTION
The m127 part is quite mundane - GrVkExtensionFlags were gone (withdrawn from public headers).

I have include the doc fix (#249) for apple shader compilation errors. Also while working on that, I found that it is good that old python code using m87-like API continues to work mostly, it is a bit confusing if one is looking at current m12x c code for reference (like trying to rewrite the sdl2 c example in python) , but having to go backward. So it would be nice to have newly written python code mimicking current c code API wise.

To that end, I found that while between m87 and m116, `SkSurfaceProps(inittype)` was removed, a simpler constructor `SkSurfaceProps()` was added to replace it - when you just want "any" and don't care - and we simply commented out the removed one only. There are a few things I'd like to add, so that the python version of the sdl example mimic the c sdl example better. etc. So a few more things to add to this. This should build fine.