### PR TITLE
Adding a __iter__ method to skia.Iter

### DIFF
--- a/src/skia/TextBlob.cpp
+++ b/src/skia/TextBlob.cpp
@@ -65,6 +65,10 @@ py::class_<SkTextBlob::Iter::Run>(iter, "Run")
 
 iter
     .def(py::init<const SkTextBlob&>())
+    .def("__iter__",
+        [] (SkTextBlob::Iter& it) {
+            return it;
+        })
     .def("__next__",
         [] (SkTextBlob::Iter& it) {
             SkTextBlob::Iter::Run run;


### PR DESCRIPTION
See
https://github.com/python/cpython/issues/128161
"Defining iterator in a separate class no longer works in 3.13"

We have iterator for SkTextBlob defined by SkTextBlob::Iter(textblob), which is the c++/pybind11 equivalent of the same situation. Following the suggestion:
https://github.com/python/cpython/issues/128161#issuecomment-2560846703

Also see https://github.com/actions/runner-images/issues/11241

Fixes #295