### PR TITLE
`StrutStyle` for leading/lineheight adjustment on `ParagraphStyle` + `TextStyle.setLetterSpacing` and `TextStyle.setWordSpacing`

### DIFF
--- a/src/skia/Paragraph.cpp
+++ b/src/skia/Paragraph.cpp
@@ -13,6 +13,7 @@ void initParagraph(py::module &m) {
 py::class_<FontCollection, sk_sp<FontCollection>, SkRefCnt> font_collection(m, "textlayout_FontCollection");
 py::class_<ParagraphBuilder> paragraph_builder(m, "textlayout_ParagraphBuilder");
 py::class_<ParagraphStyle> paragraph_style(m, "textlayout_ParagraphStyle");
+py::class_<StrutStyle> strut_style(m, "textlayout_StrutStyle");
 py::class_<TextStyle> text_style(m, "textlayout_TextStyle");
 py::class_<Paragraph> paragraph(m, "textlayout_Paragraph");
 
@@ -82,6 +83,20 @@ paragraph_builder
     .def("Build", &ParagraphBuilder::Build)
     ;
 
+strut_style
+    .def(py::init())
+    .def("setStrutEnabled",
+        py::overload_cast<const bool>(&StrutStyle::setStrutEnabled),
+        R"docstring(
+        )docstring",
+        py::arg("strutenabled"))
+    .def("setLeading",
+        py::overload_cast<const SkScalar>(&StrutStyle::setLeading),
+        R"docstring(
+        )docstring",
+        py::arg("leading"))
+    ;
+
 paragraph_style
     .def(py::init())
     .def("setTextStyle",
@@ -94,6 +109,11 @@ paragraph_style
         R"docstring(
         )docstring",
         py::arg("align"))
+    .def("setStrutStyle",
+        py::overload_cast<StrutStyle>(&ParagraphStyle::setStrutStyle),
+        R"docstring(
+        )docstring",
+        py::arg("strutstyle"))
     ;
 
 font_collection
@@ -208,6 +228,7 @@ m.attr("textlayout").attr("FontCollection") = m.attr("textlayout_FontCollection"
 m.attr("textlayout").attr("ParagraphBuilder") = m.attr("textlayout_ParagraphBuilder");
 m.attr("textlayout").attr("ParagraphStyle") = m.attr("textlayout_ParagraphStyle");
 m.attr("textlayout").attr("Paragraph") = m.attr("textlayout_Paragraph");
+m.attr("textlayout").attr("StrutStyle") = m.attr("textlayout_StrutStyle");
 m.attr("textlayout").attr("TextStyle") = m.attr("textlayout_TextStyle");
 m.attr("textlayout").attr("TextAlign") = m.attr("textlayout_TextAlign");
 m.attr("textlayout").attr("TextDecoration") = m.attr("textlayout_TextDecoration");

--- a/src/skia/Paragraph.cpp
+++ b/src/skia/Paragraph.cpp
@@ -174,6 +174,16 @@ text_style
         R"docstring(
         )docstring",
         py::arg("locale"))
+    .def("setLetterSpacing",
+        py::overload_cast<SkScalar>(&TextStyle::setLetterSpacing),
+        R"docstring(
+        )docstring",
+        py::arg("letterspacing"))
+    .def("setWordSpacing",
+        py::overload_cast<SkScalar>(&TextStyle::setWordSpacing),
+        R"docstring(
+        )docstring",
+        py::arg("wordspacing"))
     .def("setDecoration",
         py::overload_cast<TextDecoration>(&TextStyle::setDecoration),
         R"docstring(

--- a/src/skia/TextBlob.cpp
+++ b/src/skia/TextBlob.cpp
@@ -65,6 +65,10 @@ py::class_<SkTextBlob::Iter::Run>(iter, "Run")
 
 iter
     .def(py::init<const SkTextBlob&>())
+    .def("__iter__",
+        [] (SkTextBlob::Iter& it) {
+            return it;
+        })
     .def("__next__",
         [] (SkTextBlob::Iter& it) {
             SkTextBlob::Iter::Run run;

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -114,3 +114,72 @@ def test_Paragraph_strutHeight(paragraph_builder, textlayout_text_style, textlay
     zero_x_strut_height = graf_with_strut(True, 0).Height
     assert zero_x_strut_height == nostrut_height
 
+
+def test_Paragraph_letterSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+    paint = skia.Paint()
+    paint.setColor(skia.ColorBLACK)
+    paint.setAntiAlias(True)
+
+    textlayout_font_collection.setDefaultFontManager(skia.FontMgr())
+
+    def graf_with_letterspacing(letterspacing):
+        textlayout_text_style.setFontSize(50)
+        textlayout_text_style.setForegroundPaint(paint)
+        textlayout_text_style.setLetterSpacing(letterspacing)
+
+        builder = skia.textlayout.ParagraphBuilder.make(
+            paragraph_style, textlayout_font_collection, skia.Unicodes.ICU.Make()
+        )
+        builder.pushStyle(textlayout_text_style)
+
+        builder.addText("ooo")
+        paragraph = builder.Build()
+        paragraph.layout(300)
+
+        return paragraph
+    
+    negative_one_x_letter_spacing = graf_with_letterspacing(-1.0).LongestLine
+    zero_x_letter_spacing = graf_with_letterspacing(0.0).LongestLine
+    one_x_letter_spacing = graf_with_letterspacing(1.0).LongestLine
+    two_x_letter_spacing = graf_with_letterspacing(2.0).LongestLine
+    three_x_letter_spacing = graf_with_letterspacing(3.0).LongestLine
+
+    assert zero_x_letter_spacing > negative_one_x_letter_spacing
+    assert one_x_letter_spacing > zero_x_letter_spacing
+    assert two_x_letter_spacing > one_x_letter_spacing
+    assert three_x_letter_spacing > two_x_letter_spacing
+
+
+def test_Paragraph_wordSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+    paint = skia.Paint()
+    paint.setColor(skia.ColorBLACK)
+    paint.setAntiAlias(True)
+
+    textlayout_font_collection.setDefaultFontManager(skia.FontMgr())
+
+    def graf_with_word_spacing(letterspacing):
+        textlayout_text_style.setFontSize(50)
+        textlayout_text_style.setForegroundPaint(paint)
+        textlayout_text_style.setWordSpacing(letterspacing)
+
+        builder = skia.textlayout.ParagraphBuilder.make(
+            paragraph_style, textlayout_font_collection, skia.Unicodes.ICU.Make()
+        )
+        builder.pushStyle(textlayout_text_style)
+
+        builder.addText("word word word")
+        paragraph = builder.Build()
+        paragraph.layout(300)
+
+        return paragraph
+    
+    negative_one_x_word_spacing = graf_with_word_spacing(-1.0).LongestLine
+    zero_x_word_spacing = graf_with_word_spacing(0.0).LongestLine
+    one_x_word_spacing = graf_with_word_spacing(1.0).LongestLine
+    two_x_word_spacing = graf_with_word_spacing(2.0).LongestLine
+    three_x_word_spacing = graf_with_word_spacing(3.0).LongestLine
+
+    assert zero_x_word_spacing > negative_one_x_word_spacing
+    assert one_x_word_spacing > zero_x_word_spacing
+    assert two_x_word_spacing > one_x_word_spacing
+    assert three_x_word_spacing > two_x_word_spacing

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -18,6 +18,14 @@ def test_ParagraphStyle_init0(paragraph_style):
 
 
 @pytest.fixture(scope='session')
+def strut_style():
+    return skia.textlayout.StrutStyle()
+
+def test_StrutStyle_init0(strut_style):
+    assert isinstance(strut_style, skia.textlayout_StrutStyle)
+
+
+@pytest.fixture(scope='session')
 def textlayout_text_style():
     return skia.textlayout.TextStyle()
 
@@ -61,3 +69,44 @@ def test_Paragraph_linebreak(paragraph_builder, textlayout_text_style, textlayou
     paragraph = builder.Build()
     paragraph.layout(300)
     assert (paragraph.Height > 0) and (paragraph.Height > paragraph.LongestLine * 2)
+
+
+def test_Paragraph_strutHeightDifference(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+    paint = skia.Paint()
+    paint.setColor(skia.ColorBLACK)
+    paint.setAntiAlias(True)
+
+    textlayout_text_style.setFontSize(50)
+    textlayout_text_style.setForegroundPaint(paint)
+
+    textlayout_font_collection.setDefaultFontManager(skia.FontMgr())
+
+    strut_style.setStrutEnabled(False)
+    paragraph_style.setStrutStyle(strut_style)
+
+    builder = skia.textlayout.ParagraphBuilder.make(
+        paragraph_style, textlayout_font_collection, skia.Unicodes.ICU.Make()
+    )
+    builder.pushStyle(textlayout_text_style)
+
+    builder.addText("o\no")
+    paragraph = builder.Build()
+    paragraph.layout(300)
+    assert paragraph.Height > 0
+
+    nostrut_paragraph_height = paragraph.Height
+
+    strut_style.setStrutEnabled(True)
+    strut_style.setLeading(2.0)
+    
+    paragraph_style.setStrutStyle(strut_style)
+
+    builder = skia.textlayout.ParagraphBuilder.make(
+        paragraph_style, textlayout_font_collection, skia.Unicodes.ICU.Make()
+    )
+    builder.pushStyle(textlayout_text_style)
+
+    builder.addText("o\no")
+    paragraph = builder.Build()
+    paragraph.layout(300)
+    assert paragraph.Height > nostrut_paragraph_height

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -1,5 +1,6 @@
 import skia
 import pytest
+import operator
 
 @pytest.fixture(scope='session')
 def textlayout_font_collection():
@@ -71,7 +72,14 @@ def test_Paragraph_linebreak(paragraph_builder, textlayout_text_style, textlayou
     assert (paragraph.Height > 0) and (paragraph.Height > paragraph.LongestLine * 2)
 
 
-def test_Paragraph_strutHeight(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+@pytest.mark.parametrize('test_operator, spec_a, spec_b', [
+    (operator.eq, (False, 1.0), (True, 1.0)),
+    (operator.eq, (True, 0), (True, 1.0)),
+    (operator.eq, (True, 0.5), (True, 1.0)),
+    (operator.lt, (True, 1.0), (True, 2.0)),
+    (operator.lt, (True, 2.0), (True, 3.0)),
+])
+def test_Paragraph_strutHeight(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, test_operator, strut_style, spec_a, spec_b):
     paint = skia.Paint()
     paint.setColor(skia.ColorBLACK)
     paint.setAntiAlias(True)
@@ -97,25 +105,20 @@ def test_Paragraph_strutHeight(paragraph_builder, textlayout_text_style, textlay
 
         return paragraph
     
-    nostrut_height = graf_with_strut(False, 1.0).Height
-    assert nostrut_height > 0
+    paragraph_a_height = graf_with_strut(*spec_a).Height
+    paragraph_b_height = graf_with_strut(*spec_b).Height
 
-    two_x_strut_height = graf_with_strut(True, 2.0).Height
-    assert two_x_strut_height > nostrut_height
-
-    three_x_strut_height = graf_with_strut(True, 3.0).Height
-    assert three_x_strut_height > two_x_strut_height
-
-    # Anything < 1 seems to have no effect
-
-    half_strut_height = graf_with_strut(True, 0.5).Height
-    assert half_strut_height == nostrut_height
-
-    zero_x_strut_height = graf_with_strut(True, 0).Height
-    assert zero_x_strut_height == nostrut_height
+    assert test_operator(paragraph_a_height, paragraph_b_height)
 
 
-def test_Paragraph_letterSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+@pytest.mark.parametrize('spacing_a, spacing_b', [
+    (-1, 0),
+    (0, 1),
+    (1, 2),
+    (2, 3),
+    (-1, 1),
+])
+def test_Paragraph_letterSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style, spacing_a, spacing_b):
     paint = skia.Paint()
     paint.setColor(skia.ColorBLACK)
     paint.setAntiAlias(True)
@@ -138,19 +141,17 @@ def test_Paragraph_letterSpacing(paragraph_builder, textlayout_text_style, textl
 
         return paragraph
     
-    negative_one_x_letter_spacing = graf_with_letterspacing(-1.0).LongestLine
-    zero_x_letter_spacing = graf_with_letterspacing(0.0).LongestLine
-    one_x_letter_spacing = graf_with_letterspacing(1.0).LongestLine
-    two_x_letter_spacing = graf_with_letterspacing(2.0).LongestLine
-    three_x_letter_spacing = graf_with_letterspacing(3.0).LongestLine
-
-    assert zero_x_letter_spacing > negative_one_x_letter_spacing
-    assert one_x_letter_spacing > zero_x_letter_spacing
-    assert two_x_letter_spacing > one_x_letter_spacing
-    assert three_x_letter_spacing > two_x_letter_spacing
+    assert graf_with_letterspacing(spacing_a).LongestLine < graf_with_letterspacing(spacing_b).LongestLine
 
 
-def test_Paragraph_wordSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style):
+@pytest.mark.parametrize('spacing_a, spacing_b', [
+    (-1, 0),
+    (0, 1),
+    (1, 2),
+    (2, 3),
+    (-1, 1),
+])
+def test_Paragraph_wordSpacing(paragraph_builder, textlayout_text_style, textlayout_font_collection, paragraph_style, strut_style, spacing_a, spacing_b):
     paint = skia.Paint()
     paint.setColor(skia.ColorBLACK)
     paint.setAntiAlias(True)
@@ -173,13 +174,4 @@ def test_Paragraph_wordSpacing(paragraph_builder, textlayout_text_style, textlay
 
         return paragraph
     
-    negative_one_x_word_spacing = graf_with_word_spacing(-1.0).LongestLine
-    zero_x_word_spacing = graf_with_word_spacing(0.0).LongestLine
-    one_x_word_spacing = graf_with_word_spacing(1.0).LongestLine
-    two_x_word_spacing = graf_with_word_spacing(2.0).LongestLine
-    three_x_word_spacing = graf_with_word_spacing(3.0).LongestLine
-
-    assert zero_x_word_spacing > negative_one_x_word_spacing
-    assert one_x_word_spacing > zero_x_word_spacing
-    assert two_x_word_spacing > one_x_word_spacing
-    assert three_x_word_spacing > two_x_word_spacing
+    assert graf_with_word_spacing(spacing_a).LongestLine < graf_with_word_spacing(spacing_b).LongestLine


### PR DESCRIPTION
Not sure if there’s already a plan to add this in the works, but this PR adds a minimal version of `textlayout.StrutStyle` with `.setLeading` for modifying inter-line spacing with `textlayout.Paragraph`.

A code example (to modify https://github.com/HinTak/skia-python-examples/blob/main/skparagraph-example.py to get double-spacing):

```python
strut_style = textlayout.StrutStyle()
strut_style.setStrutEnabled(True)
strut_style.setLeading(2.0) # 1.0 is the default

para_style = textlayout.ParagraphStyle()
para_style.setStrutStyle(strut_style)
```