### PR TITLE
M138 public

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,19 +80,9 @@ jobs:
           - os: macos-13
             arch: arm64
             cp: "cp3{10,11,12,13}"
-          # aarch64 is emulated and takes longer, build one wheel per job
           - os: ubuntu-22.04-arm
             arch: aarch64
-            cp: cp310
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            cp: cp311
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            cp: cp312
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            cp: cp313
+            cp: "cp3{10,11,12,13}"
 
     steps:
       - uses: actions/checkout@v4
@@ -151,13 +141,9 @@ jobs:
           - os: macos-13
             arch: arm64
             cp: "cp3{8,9}"
-          # aarch64 is emulated and takes longer, build one wheel per job
           - os: ubuntu-22.04-arm
             arch: aarch64
-            cp: cp38
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            cp: cp39
+            cp: "cp3{8,9}"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   prebuild_linux_aarch64_3rd_party:
     name: Build skia bundled 3rd-party on linux/aarch64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,7 +40,7 @@ jobs:
   prebuild_linux_aarch64:
     name: Build skia on linux/aarch64
     needs: prebuild_linux_aarch64_3rd_party
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,16 +81,16 @@ jobs:
             arch: arm64
             cp: "cp3{10,11,12,13}"
           # aarch64 is emulated and takes longer, build one wheel per job
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp310
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp311
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp312
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp313
 
@@ -152,10 +152,10 @@ jobs:
             arch: arm64
             cp: "cp3{8,9}"
           # aarch64 is emulated and takes longer, build one wheel per job
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp38
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cp: cp39
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           key: linux-aarch64-skia-${{ github.sha }}-3rd-party
       - name: Pre-fetch skia deps
         if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m136-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m136-minimize-download.patch
+        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m137-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m137-minimize-download.patch
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build skia 3rd-Party

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,66 +9,8 @@ on:
     types: [published]
 
 jobs:
-  prebuild_linux_aarch64_3rd_party:
-    name: Build skia bundled 3rd-party on linux/aarch64
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: actions/cache@v4
-        id: cache-skia
-        with:
-          path: |
-            gn
-            skia
-          key: linux-aarch64-skia-${{ github.sha }}-3rd-party
-      - name: Pre-fetch skia deps
-        if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
-        run: git config --global core.compression 0 && cd skia && patch -p1 -i ../patch/skia-m137-minimize-download.patch && python tools/git-sync-deps && patch -p1 -R -i ../patch/skia-m137-minimize-download.patch
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Build skia 3rd-Party
-        # Taken from https://github.com/pypa/cibuildwheel/blob/v2.19.2/cibuildwheel/resources/pinned_docker_images.cfg
-        uses: docker://quay.io/pypa/manylinux_2_28_aarch64:2024.07.02-0
-        if: ${{ steps.cache-skia.outputs.cache-hit != 'true' }}
-        with:
-          args: bash -c "git config --global --add safe.directory '*' &&
-                         bash scripts/build_Linux.sh &&
-                         chmod a+rwx -R skia"
-
-  prebuild_linux_aarch64:
-    name: Build skia on linux/aarch64
-    needs: prebuild_linux_aarch64_3rd_party
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - uses: actions/cache@v4
-        id: cache-skia
-        with:
-          path: |
-            gn
-            skia
-          key: linux-aarch64-skia-${{ github.sha }}
-      - uses: actions/cache/restore@v4
-        with:
-          path: |
-            gn
-            skia
-          key: linux-aarch64-skia-${{ github.sha }}-3rd-party
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Build Skia Proper
-        uses: docker://quay.io/pypa/manylinux_2_28_aarch64:2024.07.02-0
-        with:
-          args: bash -c "git config --global --add safe.directory '*' &&
-                         bash scripts/build_Linux.sh
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
-    needs: prebuild_linux_aarch64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -88,20 +30,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - uses: actions/cache/restore@v4
-        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-        with:
-          path: |
-            gn
-            skia
-          key: linux-aarch64-skia-${{ github.sha }}
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
@@ -129,7 +57,6 @@ jobs:
   # identical to "build_wheels", except with the older pypa/cibuildwheel@v2.19.2
   build_wheels_old:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
-    needs: prebuild_linux_aarch64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -149,20 +76,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - uses: actions/cache/restore@v4
-        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-        with:
-          path: |
-            gn
-            skia
-          key: linux-aarch64-skia-${{ github.sha }}
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux' && matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.2

--- a/patch/skia-m137-minimize-download.patch
+++ b/patch/skia-m137-minimize-download.patch
@@ -1,0 +1,70 @@
+diff --git a/DEPS b/DEPS
+index 3c7ca04..a16b21d 100644
+--- a/DEPS
++++ b/DEPS
+@@ -31,53 +31,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@729495f2ffa69080907780591fa2a630b2556e98",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@cdb34025f286a0ded80c34c4edae180539e24dc1",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@1a81a31c86f24b217d6396bc0a4c796590fffc43",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@e2d024354e11cc6b041b0cff032d73f0c7e43a07",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794",
+-  "third_party/externals/abseil-cpp"             : "https://skia.googlesource.com/external/github.com/abseil/abseil-cpp.git@65a55c2ba891f6d2492477707f4a2e327a0b40dc",
+-  "third_party/externals/delaunator-cpp"         : "https://skia.googlesource.com/external/github.com/skia-dev/delaunator-cpp.git@98305ef6c4e862f7d48df9cc647b690d796fec68",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@624da0f593bb8d7e146b9f42b06d8e6c80d032a3",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@5d4e649f740c675426fbe4cdaffc53ee2a4cb954",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@ca3cd48fa3e06fa81d7c8a3f716cca44ed2de26a",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@364118a1d9da24bb5b770ac3d762ac144d6da5a4",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@bcf4f7198d4dc5f3127e84a6ca657c88e7d07a13",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@ed217e3e601d8e462f7fd1e04bed43ac42212429",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@845d5476a866141ba35ac133f856fa62f0b7445f",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/partition_alloc"        : "https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git@ce13777cb731e0a60c606d1741091fd11a0574d7",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@7905fa19e456df5aa8e2233a7ec5832c9c6c287b",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@95177446886dc95356c1662dbdc6e545233b3174",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+   "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@bab63ff679c41eb75fc67dac76e1dc44426101e1",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@783d7033613cedaa7147d0700b517abc5c32312d",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@3ee3bea02164c5a816fe6c16ef4e3a810edb7620",
+-  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@e2e53a724677f6eba8ff0ce1ccb64ee321785cbd",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@682e42f7ae70a8fadf374199c02de737daa5c70d",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@4e246c56ec5afb5ad66b9b04374d39ac04675c8e",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@646b7f569718921d7d4b5b8e22572ff6c76f2596",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/patch/skia-m138-minimize-download.patch
+++ b/patch/skia-m138-minimize-download.patch
@@ -1,0 +1,70 @@
+diff --git a/DEPS b/DEPS
+index 178d30b..a16b21d 100644
+--- a/DEPS
++++ b/DEPS
+@@ -31,53 +31,18 @@ vars = {
+ #     ./tools/git-sync-deps
+ deps = {
+   "buildtools"                                   : "https://chromium.googlesource.com/chromium/src/buildtools.git@729495f2ffa69080907780591fa2a630b2556e98",
+-  "third_party/externals/angle2"                 : "https://chromium.googlesource.com/angle/angle.git@ec4d8f8e4d3f1a9e64430abd8b6b436253732adf",
+-  "third_party/externals/brotli"                 : "https://skia.googlesource.com/external/github.com/google/brotli.git@6d03dfbedda1615c4cba1211f8d81735575209c8",
+-  "third_party/externals/d3d12allocator"         : "https://skia.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git@169895d529dfce00390a20e69c2f516066fe7a3b",
+-  # Dawn requires jinja2 and markupsafe for the code generator, tint for SPIRV compilation, and abseil for string formatting.
+-  # When the Dawn revision is updated these should be updated from the Dawn DEPS as well.
+-  "third_party/externals/dawn"                   : "https://dawn.googlesource.com/dawn.git@30e8f3c65d1708b5bfec3a6290c2b58a792d1899",
+-  "third_party/externals/jinja2"                 : "https://chromium.googlesource.com/chromium/src/third_party/jinja2@e2d024354e11cc6b041b0cff032d73f0c7e43a07",
+-  "third_party/externals/markupsafe"             : "https://chromium.googlesource.com/chromium/src/third_party/markupsafe@0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794",
+-  "third_party/externals/abseil-cpp"             : "https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp@04dc59d2c83238cb1fcb49083e5e416643a899ce",
+-  "third_party/externals/delaunator-cpp"         : "https://skia.googlesource.com/external/github.com/skia-dev/delaunator-cpp.git@98305ef6c4e862f7d48df9cc647b690d796fec68",
+   "third_party/externals/dng_sdk"                : "https://android.googlesource.com/platform/external/dng_sdk.git@dbe0a676450d9b8c71bf00688bb306409b779e90",
+-  "third_party/externals/egl-registry"           : "https://skia.googlesource.com/external/github.com/KhronosGroup/EGL-Registry@b055c9b483e70ecd57b3cf7204db21f5a06f9ffe",
+-  "third_party/externals/emsdk"                  : "https://skia.googlesource.com/external/github.com/emscripten-core/emsdk.git@a896e3d066448b3530dbcaa48869fafefd738f57",
+   "third_party/externals/expat"                  : "https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git@8e49998f003d693213b538ef765814c7d21abada",
+   "third_party/externals/freetype"               : "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git@702e4a1d32e4b911e85cc7df84b3ba395c28dab3",
+   "third_party/externals/harfbuzz"               : "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git@08b52ae2e44931eef163dbad71697f911fadc323",
+-  "third_party/externals/highway"                : "https://chromium.googlesource.com/external/github.com/google/highway.git@424360251cdcfc314cfc528f53c872ecd63af0f0",
+   "third_party/externals/icu"                    : "https://chromium.googlesource.com/chromium/deps/icu.git@364118a1d9da24bb5b770ac3d762ac144d6da5a4",
+-  "third_party/externals/icu4x"                  : "https://chromium.googlesource.com/external/github.com/unicode-org/icu4x.git@bcf4f7198d4dc5f3127e84a6ca657c88e7d07a13",
+-  "third_party/externals/imgui"                  : "https://skia.googlesource.com/external/github.com/ocornut/imgui.git@55d35d8387c15bf0cfd71861df67af8cfbda7456",
+-  "third_party/externals/libavif"                : "https://skia.googlesource.com/external/github.com/AOMediaCodec/libavif.git@55aab4ac0607ab651055d354d64c4615cf3d8000",
+-  "third_party/externals/libgav1"                : "https://chromium.googlesource.com/codecs/libgav1.git@5cf722e659014ebaf2f573a6dd935116d36eadf1",
+-  "third_party/externals/libgrapheme"            : "https://skia.googlesource.com/external/github.com/FRIGN/libgrapheme/@c0cab63c5300fa12284194fbef57aa2ed62a94c0",
+   "third_party/externals/libjpeg-turbo"          : "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git@e14cbfaa85529d47f9f55b0f104a579c1061f9ad",
+-  "third_party/externals/libjxl"                 : "https://chromium.googlesource.com/external/gitlab.com/wg1/jpeg-xl.git@a205468bc5d3a353fb15dae2398a101dff52f2d3",
+   "third_party/externals/libpng"                 : "https://skia.googlesource.com/third_party/libpng.git@ed217e3e601d8e462f7fd1e04bed43ac42212429",
+   "third_party/externals/libwebp"                : "https://chromium.googlesource.com/webm/libwebp.git@845d5476a866141ba35ac133f856fa62f0b7445f",
+-  "third_party/externals/libyuv"                 : "https://chromium.googlesource.com/libyuv/libyuv.git@d248929c059ff7629a85333699717d7a677d8d96",
+-  "third_party/externals/oboe"                   : "https://chromium.googlesource.com/external/github.com/google/oboe.git@b02a12d1dd821118763debec6b83d00a8a0ee419",
+-  "third_party/externals/opengl-registry"        : "https://skia.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry@14b80ebeab022b2c78f84a573f01028c96075553",
+-  "third_party/externals/partition_alloc"        : "https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git@ce13777cb731e0a60c606d1741091fd11a0574d7",
+-  "third_party/externals/perfetto"               : "https://android.googlesource.com/platform/external/perfetto@93885509be1c9240bc55fa515ceb34811e54a394",
+   "third_party/externals/piex"                   : "https://android.googlesource.com/platform/external/piex.git@bb217acdca1cc0c16b704669dd6f91a1b509c406",
+-  "third_party/externals/swiftshader"            : "https://swiftshader.googlesource.com/SwiftShader@a8133cbb3c8969e3c1e6b3cea2c02ec8312ef9ca",
+   "third_party/externals/vulkanmemoryallocator"  : "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator@a6bfc237255a6bac1513f7c1ebde6d8aed6b5191",
+-  # vulkan-deps is a meta-repo containing several interdependent Khronos Vulkan repositories.
+-  # When the vulkan-deps revision is updated, those repos (spirv-*, vulkan-*) should be updated as well.
+   "third_party/externals/vulkan-deps"            : "https://chromium.googlesource.com/vulkan-deps@d5a5fd31a4fe219410e13c93c8f3c0b237df65fc",
+-  "third_party/externals/spirv-cross"            : "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross@b8fcf307f1f347089e3c46eb4451d27f32ebc8d3",
+   "third_party/externals/spirv-headers"          : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git@c9aad99f9276817f18f72a4696239237c83cb775",
+-  "third_party/externals/spirv-tools"            : "https://skia.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git@01021466b5e71deaac9054f56082566c782bfd51",
+-  "third_party/externals/vello"                  : "https://skia.googlesource.com/external/github.com/linebender/vello.git@3ee3bea02164c5a816fe6c16ef4e3a810edb7620",
+-  "third_party/externals/vulkan-headers"         : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers@75ad707a587e1469fb53a901b9b68fe9f6fbc11f",
+-  "third_party/externals/vulkan-tools"           : "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools@60b640cb931814fcc6dabe4fc61f4738c56579f6",
+-  "third_party/externals/vulkan-utility-libraries": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries@ae56bd6e65d9faa731150e931cb35f0d895223bc",
+-  "third_party/externals/unicodetools"           : "https://chromium.googlesource.com/external/github.com/unicode-org/unicodetools@66a3fa9dbdca3b67053a483d130564eabc5fe095",
+-  #"third_party/externals/v8"                     : "https://chromium.googlesource.com/v8/v8.git@5f1ae66d5634e43563b2d25ea652dfb94c31a3b4",
+   "third_party/externals/wuffs"                  : "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git@e3f919ccfe3ef542cfc983a82146070258fb57f8",
+   "third_party/externals/zlib"                   : "https://chromium.googlesource.com/chromium/src/third_party/zlib@646b7f569718921d7d4b5b8e22572ff6c76f2596",
+ 
+diff --git a/bin/activate-emsdk b/bin/activate-emsdk
+index 687ca9f..7167d8d 100755
+--- a/bin/activate-emsdk
++++ b/bin/activate-emsdk
+@@ -17,6 +17,7 @@ EMSDK_PATH = os.path.join(EMSDK_ROOT, 'emsdk.py')
+ EMSDK_VERSION = '3.1.44'
+ 
+ def main():
++    return
+     if sysconfig.get_platform() in ['linux-aarch64', 'linux-arm64']:
+         # This platform cannot install emsdk at the provided version. See
+         # https://github.com/emscripten-core/emsdk/blob/main/emscripten-releases-tags.json#L5

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -22,7 +22,7 @@ fi
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m138-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     gn gen out/Release --args="

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -12,39 +12,26 @@ export LDFLAGS="-lrt"
 
 # Install system dependencies
 if [[ $EUID -eq 0 ]]; then
+    yum -y install epel-release && \
     yum install -y \
         python3 \
+        ninja-build gn \
         fontconfig-devel \
         mesa-libGL-devel \
         xorg-x11-server-Xvfb \
         mesa-dri-drivers && \
         yum clean all && \
+        mv depot_tools/ninja depot_tools/ninja.bak && \
+        mv depot_tools/gn depot_tools/gn.bak && \
         rm -rf /var/cache/yum
 fi
-
-if [[ $(uname -m) == "aarch64" ]]; then
-    # Install ninja for aarch64
-    yum -y install epel-release && \
-        yum repolist && \
-        yum install -y ninja-build && \
-        mv depot_tools/ninja depot_tools/ninja.bak
-fi
-
-# Build gn
-git clone https://gn.googlesource.com/gn && \
-    cd gn && \
-    git checkout fe330c0ae1ec29db30b6f830e50771a335e071fb && \
-    python3 build/gen.py && \
-    ninja -C out gn && \
-    cd ..
 
 # Build skia
 cd skia && \
     patch -p1 < ../patch/skia-m137-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
-    cp -f ../gn/out/gn bin/gn && \
-    bin/gn gen out/Release --args="
+    gn gen out/Release --args="
 is_official_build=true
 skia_enable_svg=true
 skia_use_vulkan=true

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -59,7 +59,7 @@ git clone https://gn.googlesource.com/gn && \
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m136-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     cp -f ../gn/out/gn bin/gn && \

--- a/scripts/build_Linux.sh
+++ b/scripts/build_Linux.sh
@@ -4,12 +4,6 @@ export PATH=${PWD}/depot_tools:$PATH
 
 EXTRA_CFLAGS=""
 
-export CC=gcc
-export CXX=g++
-export AR=ar
-export CFLAGS="-Wno-deprecated-copy"
-export LDFLAGS="-lrt"
-
 # Install system dependencies
 if [[ $EUID -eq 0 ]]; then
     yum -y install epel-release && \

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,7 +4,7 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m138-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='

--- a/scripts/build_Windows.sh
+++ b/scripts/build_Windows.sh
@@ -4,7 +4,7 @@ export PATH="${PWD}/depot_tools:$PATH"
 
 # Build skia
 cd skia && \
-    patch -p1 < ../patch/skia-m136-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python tools/git-sync-deps && \
     bin/gn gen out/Release --args='

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,7 +22,7 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m136-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="

--- a/scripts/build_macOS.sh
+++ b/scripts/build_macOS.sh
@@ -22,7 +22,7 @@ function apply_patch {
 }
 
 cd skia && \
-    patch -p1 < ../patch/skia-m137-minimize-download.patch && \
+    patch -p1 < ../patch/skia-m138-minimize-download.patch && \
     patch -p1 < ../patch/skia-m132-colrv1-freetype.diff && \
     python3 tools/git-sync-deps && \
     bin/gn gen out/Release --args="

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '136.0b13'
+__version__ = '138.0rc1'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -928,7 +928,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
     //     "Enumerates all cached GPU resources and dumps their memory to "
     //     "traceMemoryDump.")
     .def("supportsDistanceFieldText", &GrDirectContext::supportsDistanceFieldText)
-    .def("storeVkPipelineCacheData", &GrDirectContext::storeVkPipelineCacheData)
+    .def("storeVkPipelineCacheData", py::overload_cast<>(&GrDirectContext::storeVkPipelineCacheData))
     .def_static("ComputeImageSize",
         [] (sk_sp<SkImage> image, skgpu::Mipmapped mapped, bool useNextPow2) {
             // REVISIT: process skgpu::Mipmapped and useNextPow2 = true

--- a/src/skia/Image.cpp
+++ b/src/skia/Image.cpp
@@ -1398,7 +1398,7 @@ image
 
         :return: true if :py:class:`Image` is a GPU texture
         )docstring")
-    .def("isValid", &SkImage::isValid,
+    .def("isValid", py::overload_cast<GrRecordingContext*>(&SkImage::isValid, py::const_),
         R"docstring(
         Returns true if :py:class:`Image` can be drawn on either raster surface
         or GPU surface.


### PR DESCRIPTION
Nothing interesting happened upstream between m136 and m138. Inclusive of #321 and part of #314 (the part that does native aarch64 linux builds). However, a few large additions (#322 , #329 ) and a small one (#324) .

@kyamagu I'll pull all of those into here when the separate CIs finishes, and let you know after I add a README.m138 . How do you feel about EGL ? That pull has bit-rotten slightly, so it needs an update before merging, but looks like wayland is coming and EGL will replace GLX / X11 at some point.