### PR TITLE
Use python 3.11, and install libEGL for docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,0 +1,33 @@
+name: Build and Upload Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+# This is identical to "build_docs" in ci except for not using/dependent on
+# newly built wheels, and trigged on manual.
+  build_docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.11'
+
+      - name: Build docs
+        run: |
+          # installing libegl1 will also install libegl-mesa0
+          sudo apt-get -y install libegl1
+          python -m pip install --pre skia-python
+          python -m pip install sphinx==6.2.1 sphinx-rtd-theme
+          python setup.py build_sphinx
+
+      - name: Deploy docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - uses: actions/download-artifact@v4
         with:
@@ -162,6 +162,8 @@ jobs:
 
       - name: Build docs
         run: |
+          # installing libegl1 will also install libegl-mesa0
+          sudo apt-get -y install libegl1
           python -m pip install --pre -f dist skia-python
           python -m pip install sphinx==6.2.1 sphinx-rtd-theme
           python setup.py build_sphinx

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ to use it in 2021 (instead of the older `libGLX.so`), so it is likely newer Linu
 already have it, but please check. skia-python v138.rc1+ supports hardware acceleration
 via both GLX (still the default under X11) and EGL (newly added).
 
-For Linux platforms, there must be OpenGL, libEGL and fontconfig installed:
+For Linux platforms, there must be OpenGL, libEGL and fontconfig installed.
+Current Ubuntu needs `libegl1` (and `libegl-mesa0`); on older Ubuntu the package names are
+`libglvnd0` and `libgl1-mesa-egl`:
+
+
 
 ```bash
 apt-get install libfontconfig1 libgl1-mesa-glx libgl1-mesa-egl libegl1 libglvnd0 libgl1-mesa-dri


### PR DESCRIPTION
3.8 EOL soon

Adding manual by-pass

Fixes #334

@kyamagu this also adds a trigger to rebuild and upload docs at manual request - this means the docs can be updated between releases...