### PR TITLE
V138.0 release

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -23,8 +23,8 @@ jobs:
           # installing libegl1 will also install libegl-mesa0
           sudo apt-get -y install libegl1
           python -m pip install --pre skia-python
-          python -m pip install sphinx==6.2.1 sphinx-rtd-theme
-          python setup.py build_sphinx
+          python -m pip install sphinx sphinx-rtd-theme
+          sphinx-build -b html docs docs/_build/html
 
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,8 @@ jobs:
           # installing libegl1 will also install libegl-mesa0
           sudo apt-get -y install libegl1
           python -m pip install --pre -f dist skia-python
-          python -m pip install sphinx==6.2.1 sphinx-rtd-theme
-          python setup.py build_sphinx
+          python -m pip install sphinx sphinx-rtd-theme
+          sphinx-build -b html docs docs/_build/html
 
       - name: Deploy docs
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,14 @@ jobs:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-13]
         arch: [auto64]
-        cp: ["cp39"]
+        cp: ["cp3{8,9}"]
         include:
           - os: macos-13
             arch: arm64
-            cp: "cp39"
+            cp: "cp3{8,9}"
           - os: ubuntu-22.04-arm
             arch: aarch64
-            cp: "cp39"
+            cp: "cp3{8,9}"
 
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.8'
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-22.04-arm
             arch: aarch64
             cp: "cp3{10,11,12,13}"
+          - os: windows-11-arm
+            arch: ARM64
+            cp: "cp3{11,12,13}"
 
     steps:
       - uses: actions/checkout@v4
@@ -49,45 +52,6 @@ jobs:
           CIBW_TEST_COMMAND_LINUX: >
             xvfb-run -s "-screen 0 640x480x24" python -m pytest {project}/tests
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair --exclude libEGL.so.1 -w {dest_dir} {wheel}"
-          CIBW_TEST_SKIP: "*-macosx_arm64"
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheel-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.cp }}
-          path: ./wheelhouse/*.whl
-
-  build_wheels_armwindows:
-    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) for ${{ matrix.cp }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-11-arm]
-        arch: [ARM64]
-        cp: ["cp3{11,12,13}"]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
-        env:
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-          CIBW_BUILD: "${{ matrix.cp }}-*"
-          CIBW_SKIP: "*musllinux*"
-          CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_ENVIRONMENT_MACOS: TARGET_ARCH=${{ matrix.arch }} MACOSX_DEPLOYMENT_TARGET=11.0
-          CIBW_BEFORE_ALL: bash scripts/build_${{ runner.os }}.sh
-          CIBW_BEFORE_BUILD: pip install pybind11 numpy
-          CIBW_BEFORE_BUILD_WINDOWS: pip install pybind11 "numpy >= 2.3.0rc1"
-          CIBW_TEST_REQUIRES: pytest pillow glfw
-          CIBW_TEST_REQUIRES_MACOS: pytest pillow pyopengl
-          CIBW_TEST_COMMAND: python -m pytest {project}/tests
-          CIBW_TEST_COMMAND_LINUX: >
-            xvfb-run -s "-screen 0 640x480x24" python -m pytest {project}/tests
           CIBW_TEST_SKIP: "*-macosx_arm64"
 
       - uses: actions/upload-artifact@v4
@@ -145,7 +109,7 @@ jobs:
 
   build_docs:
     name: Build docs
-    needs: [build_wheels, build_wheels_armwindows, build_wheels_old]
+    needs: [build_wheels, build_wheels_old]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -177,7 +141,7 @@ jobs:
 
   publish:
     name: Upload packages to PyPI
-    needs: [build_wheels, build_wheels_armwindows, build_wheels_old]
+    needs: [build_wheels, build_wheels_old]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     permissions:

--- a/Migration_from_v8x_to_v13x.md
+++ b/Migration_from_v8x_to_v13x.md
@@ -1,0 +1,40 @@
+v13x offers a lot of new functionality. This document covers breaking changes
+when upgrading from v8x.
+
+- Linux users: `libEGL.so` (from mesa-libEGL, libglvnd, or your graphic
+  card's vendor e.g. NVidia) is required to be present on Linux hosts.
+  This is associated with the general change on Linux from X11 to Wayland,
+  and from GTK3 to GTK4.
+
+- Apple users and non-open-source GPU driver: Upstream added subtantial
+  GPU/driver detection code. You may need to request compatible OpenGL
+  profile to match your GPU/driver's capability. For Apple Mac users,
+  with `glfw`, adds the following:
+
+```
+# see https://www.glfw.org/faq#macos
+glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
+glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 2)
+glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, True)
+glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
+```
+
+  Other examples are in [README.m116](relnotes/README.m116.md).
+
+# General
+
+- Some routines need a new `skia.SamplingOptions()` argument, or
+  switch from `skia.FilterQuality` to `skia.SamplingOptions()`.
+  See [README.m124](relnotes/README.m124.md) for migration from
+  `skia.FilterQuality`.
+
+- `Typeface()` and `Typeface.MakeDefault()` now emit a Deprecation Warning.
+  Use `Typeface("")` instead. Also avoid `skia.Font()` and
+  `skia.Font(None, ...)` ; e.g. `skia.Font(skia.Typeface(''))` should be used.
+  See [README.m121](relnotes/README.m121.md)
+
+- A fair number of `skia.ImageFilter.*Filter` and `skia.*PathEffect` are
+  gone. Sorry. Upstream likely recommends reimplementation with `skia.RuntimeEffect`.
+  Please file issues, or better, pulls to emulate those old APIs. TODO
+
+- Misc small changes everywhere.

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Supported platforms: Python 3.8-3.13 (CPython) on
 - macOS x86_64, arm64
 - Windows x86_64, arm64 ; arm64 for the windows 11 and Python 3.11-3.13 combination only.
 
-**IMPORTANT:** Starting v138rc1, `libEGL.so` (from mesa-libEGL, libglvnd, or your graphic
+**IMPORTANT:** Starting v87.9rc1 / v138.0rc1, `libEGL.so` (from mesa-libEGL, libglvnd, or your graphic
 card's vendor e.g. NVidia) is required to be present on Linux hosts. This is associated
 with the general change on Linux from X11 to Wayland, and from GTK3 to GTK4. Firefox started
 to use it in 2021 (instead of the older `libGLX.so`), so it is likely newer Linux systems
-already have it, but please check. skia-python v138.rc1+ supports hardware acceleration
+already have it, but please check. skia-python v87.9 / v138.0+ supports hardware acceleration
 via both GLX (still the default under X11) and EGL (newly added).
 
 For Linux platforms, there must be OpenGL, libEGL and fontconfig installed.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ https://kyamagu.github.io/skia-python
 - [Tutorial](https://kyamagu.github.io/skia-python/tutorial/)
 - [Reference](https://kyamagu.github.io/skia-python/reference.html)
 
-- For information about changes after `m116`, and tips on migration from `m87`: [README.m116](relnotes/README.m116.md),
+- For breaking changes and tips on migration from `m87`: See [Migration Guide](Migration_from_v8x_to_v13x.md), also
+  see the detailed changes below, especially [README.m116](relnotes/README.m116.md).
+
+- For information about changes after `m116`: [README.m116](relnotes/README.m116.md),
   [README.m117](relnotes/README.m117.md), [README.m118](relnotes/README.m118.md), [README.m119](relnotes/README.m119.md),
   [README.m120](relnotes/README.m120.md), [README.m121](relnotes/README.m121.md), [README.m122](relnotes/README.m122.md),
   [README.m123](relnotes/README.m123.md), [README.m124](relnotes/README.m124.md), [README.m125](relnotes/README.m125.md),

--- a/relnotes/README.m116.md
+++ b/relnotes/README.m116.md
@@ -45,7 +45,7 @@ of this update had taken from.
   detection code in upsteam Skia between m87 and m116, to optimize for speed and
   work-around driver bugs. If you use a non-open-source GPU driver, i.e.
   everybody except Mesa on Linux, and especially Apple Mac users,
-  you may need to request compatible OpenGL profile to match the your
+  you may need to request compatible OpenGL profile to match your
   GPU/driver's capability. For Apple Mac users, with `glfw`, adds the following:
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -178,8 +178,7 @@ setup(
     ext_modules=[extension],
     data_files=data_files,
     install_requires=[
-        'numpy; sys_platform != "win32" or python_version <= "3.10"',
-        'numpy>=2.3.0rc1; sys_platform == "win32" and python_version >= "3.11"',
+        'numpy',
         'pybind11>=2.6'
     ],
     setup_requires=['pybind11>=2.6'],

--- a/setup.py
+++ b/setup.py
@@ -184,15 +184,6 @@ setup(
     ],
     setup_requires=['pybind11>=2.6'],
     cmdclass={'build_ext': BuildExt},
-    command_options={
-        'build_sphinx': {
-            'project': ('setup.py', NAME),
-            'version': ('setup.py', __version__),
-            'release': ('setup.py', __version__),
-            'source_dir': ('setup.py', 'docs'),
-            'build_dir': ('setup.py', 'docs/_build'),
-        },
-    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     pass
 
 NAME = 'skia-python'
-__version__ = '138.0rc1'
+__version__ = '138.0'
 
 SKIA_PATH = os.getenv('SKIA_PATH', 'skia')
 SKIA_OUT_PATH = os.getenv(

--- a/src/skia/GrContext.cpp
+++ b/src/skia/GrContext.cpp
@@ -956,7 +956,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
 
         The client should ensure that the returned backend texture is valid.
         For the Vulkan backend the layout of the created VkImage will be:
-             VK_IMAGE_LAYOUT_UNDEFINED.
+        VK_IMAGE_LAYOUT_UNDEFINED .
         )docstring",
         py::arg("width"), py::arg("height"), py::arg("backendFormat"),
         py::arg("mipMapped"), py::arg("renderable"),
@@ -996,7 +996,7 @@ py::class_<GrDirectContext, sk_sp<GrDirectContext>, GrRecordingContext>(m, "GrDi
         The finishedProc will always get called even if we failed to create the
         GrBackendTexture.
         For the Vulkan backend the layout of the created VkImage will be:
-            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL .
         )docstring",
         py::arg("width"), py::arg("height"), py::arg("backendFormat"),
         py::arg("color"), py::arg("mipMapped"), py::arg("renderable"),

--- a/src/skia/RuntimeEffect.cpp
+++ b/src/skia/RuntimeEffect.cpp
@@ -24,7 +24,7 @@ py::class_<SkRuntimeEffectBuilder> runtime_effect_builder(m, "RuntimeEffectBuild
 
 py::enum_<SkRuntimeEffect::ChildType>(runtime_effect, "ChildType")
     .value("kShader",       SkRuntimeEffect::ChildType::kShader)
-    .value("kColorFilter,", SkRuntimeEffect::ChildType::kColorFilter)
+    .value("kColorFilter", SkRuntimeEffect::ChildType::kColorFilter)
     .value("kBlender",      SkRuntimeEffect::ChildType::kBlender)
     .export_values();
 


### PR DESCRIPTION
Nothing exciting, just removing the numpy related conditionals, and some small doc related updates.

Apparently I was wrong about python 3.8 - it continues to be available under setup-python (and its derivatives). That it is EOL last autumn, true 