### PR TITLE
Revert "Upload wheel-fedora:42"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,6 @@ jobs:
           submodules: recursive
        - run: bash scripts/build_Linux.sh
        - run: python -m build --wheel
-       - uses: actions/upload-artifact@v4
-         with:
-           name: wheel-fedora-42
-           path: ./dist/*.whl
        - run: python -m pip install dist/*.whl
        - run: python -m pip install moderngl
        - run: python -c 'import skia; print(skia.__version__)'


### PR DESCRIPTION
This reverts commit 300f7305b1348563ec801fe66a000f50beadabb4.

Fixes #359

@kyamagu sorry this block the release - upload was alphabetical so stopped after 3.11 and 3.12 (at the unusually named 3.13 fedora wheel).